### PR TITLE
Fix Xcode autocomplete

### DIFF
--- a/Sources/Extensions/NSView+PinLayout.swift
+++ b/Sources/Extensions/NSView+PinLayout.swift
@@ -25,6 +25,18 @@ import AppKit
 extension NSView: Layoutable {
     public typealias View = NSView
 
+    public var pin: PinLayout<NSView> {
+        return PinLayout(view: self, keepTransform: true)
+    }
+
+    public var pinFrame: PinLayout<NSView> {
+        return PinLayout(view: self, keepTransform: false)
+    }
+
+    @objc public var pinObjc: PinLayoutObjC {
+        return PinLayoutObjCImpl(view: self, keepTransform: true)
+    }
+
     public func getRect(keepTransform: Bool) -> CGRect {
         if let superview = superview, !superview.isFlipped {
             var flippedRect = frame
@@ -53,11 +65,6 @@ extension NSView: Layoutable {
         case .ltr:  return true
         case .rtl:  return false
         }
-    }
-
-    // Expose PinLayout's objective-c interface.
-    @objc public var pinObjc: PinLayoutObjC {
-        return PinLayoutObjCImpl(view: self, keepTransform: true)
     }
 }
 

--- a/Sources/Extensions/UIView+PinLayout.swift
+++ b/Sources/Extensions/UIView+PinLayout.swift
@@ -25,6 +25,18 @@ import UIKit
 extension UIView: Layoutable, SizeCalculable {
     public typealias View = UIView
 
+    public var pin: PinLayout<UIView> {
+        return PinLayout(view: self, keepTransform: true)
+    }
+
+    public var pinFrame: PinLayout<UIView> {
+        return PinLayout(view: self, keepTransform: false)
+    }
+
+    @objc public var pinObjc: PinLayoutObjC {
+        return PinLayoutObjCImpl(view: self, keepTransform: true)
+    }
+
     public func getRect(keepTransform: Bool) -> CGRect {
         if keepTransform {
             /*
@@ -78,11 +90,6 @@ extension UIView: Layoutable, SizeCalculable {
         case .ltr: return true
         case .rtl: return false
         }
-    }
-
-    // Expose PinLayout's objective-c interface.
-    @objc public var pinObjc: PinLayoutObjC {
-        return PinLayoutObjCImpl(view: self, keepTransform: true)
     }
 }
 

--- a/Sources/Layoutable+PinLayout.swift
+++ b/Sources/Layoutable+PinLayout.swift
@@ -9,14 +9,6 @@
 import Foundation
 
 extension Layoutable {
-    public var pin: PinLayout<View> {
-        return PinLayout(view: self as! Self.View, keepTransform: true)
-    }
-
-    public var pinFrame: PinLayout<View> {
-        return PinLayout(view: self as! Self.View, keepTransform: false)
-    }
-
     public var anchor: AnchorList {
         return AnchorListImpl(view: self as! View)
     }


### PR DESCRIPTION
Now shows UIView/NSView instead of UIView.View/NSView.View.

<img width="812" alt="screen shot 2018-06-15 at 6 53 06 am" src="https://user-images.githubusercontent.com/14981341/41536034-5e58880a-72d2-11e8-96aa-75d6d45a001f.png">
