### PR TITLE
Fix a regression

### DIFF
--- a/Sources/Extensions/CALayer+PinLayout.swift
+++ b/Sources/Extensions/CALayer+PinLayout.swift
@@ -30,12 +30,11 @@ extension CALayer: Layoutable {
     public func getRect(keepTransform: Bool) -> CGRect {
         if keepTransform {
             /*
-             To adjust the view's position and size, we don't set the UIView's frame directly, because we want to keep the
-             view's transform (UIView.transform).
-             By setting the view's center and bounds we really set the frame of the non-transformed view, and this keep
-             the view's transform. So view's transforms won't be affected/altered by PinLayout.
+             To adjust the layer's position and size, we don't set the layer's frame directly, because we want to keep the
+             layer's transform.
+             By setting the layer's center and bounds we really set the frame of the non-transformed layer, and this keep
+             the layer's transform. So layer's transforms won't be affected/altered by PinLayout.
              */
-
             let size = bounds.size
             // See setRect(...) for details about this calculation.
             let origin = CGPoint(x: position.x - (size.width * anchorPoint.x),
@@ -52,10 +51,10 @@ extension CALayer: Layoutable {
 
         if keepTransform {
             /*
-             To adjust the view's position and size, we don't set the UIView's frame directly, because we want to keep the
-             view's transform (UIView.transform).
-             By setting the view's center and bounds we really set the frame of the non-transformed view, and this keep
-             the view's transform. So view's transforms won't be affected/altered by PinLayout.
+             To adjust the layer's position and size, we don't set the layer's frame directly, because we want to keep the
+             layer's transform.
+             By setting the layer's center and bounds we really set the frame of the non-transformed layer, and this keep
+             the layer's transform. So layer's transforms won't be affected/altered by PinLayout.
              */
 
             // NOTE: The center is offset by the layer.anchorPoint, so we have to take it into account.

--- a/Sources/Extensions/UIView+PinLayout.swift
+++ b/Sources/Extensions/UIView+PinLayout.swift
@@ -38,11 +38,43 @@ extension UIView: Layoutable, SizeCalculable {
     }
 
     public func getRect(keepTransform: Bool) -> CGRect {
-        return layer.getRect(keepTransform: keepTransform)
+        if keepTransform {
+            /*
+             To adjust the view's position and size, we don't set the UIView's frame directly, because we want to keep the
+             view's transform (UIView.transform).
+             By setting the view's center and bounds we really set the frame of the non-transformed view, and this keep
+             the view's transform. So view's transforms won't be affected/altered by PinLayout.
+             */
+            let size = bounds.size
+            // See setRect(...) for details about this calculation.
+            let origin = CGPoint(x: center.x - (size.width * layer.anchorPoint.x),
+                                 y: center.y - (size.height * layer.anchorPoint.y))
+
+            return CGRect(origin: origin, size: size)
+        } else {
+            return frame
+        }
     }
 
     public func setRect(_ rect: CGRect, keepTransform: Bool) {
-        layer.setRect(rect, keepTransform: keepTransform)
+        let adjustedRect = Coordinates<View>.adjustRectToDisplayScale(rect)
+
+        if keepTransform {
+            /*
+             To adjust the view's position and size, we don't set the UIView's frame directly, because we want to keep the
+             view's transform (UIView.transform).
+             By setting the view's center and bounds we really set the frame of the non-transformed view, and this keep
+             the view's transform. So view's transforms won't be affected/altered by PinLayout.
+             */
+
+            // NOTE: The center is offset by the layer.anchorPoint, so we have to take it into account.
+            center = CGPoint(x: adjustedRect.origin.x + (adjustedRect.width * layer.anchorPoint.x),
+                             y: adjustedRect.origin.y + (adjustedRect.height * layer.anchorPoint.y))
+            // NOTE: We must set only the bounds's size and keep the origin.
+            bounds.size = adjustedRect.size
+        } else {
+            frame = adjustedRect
+        }
     }
 
     public func isLTR() -> Bool {


### PR DESCRIPTION
The recent changes to PinLayout that enable the layout of CALayer has impacted the layout of UIViews. Some investigations would need to be done to understand correctly the issue. For now, we just revert one of the changes.