### PR TITLE
Method that position multiple edges now accept an "offset" parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@
 
 # Change Log
 
+## [1.7.11](https://github.com/layoutBox/PinLayout/releases/tag/1.7.11)
+Released on 2018-08-05
+
+#### Method that position multiple edges now accept an `offset` parameter.
+The `offset` parameter that specifies the distance from their superview's corresponding edges in pixels.
+
+**New methods:**
+
+* `topLeft(_ offset: CGFloat)`
+* `topCenter(_ topOffset: CGFloat)`
+* `topRight(_ offset: CGFloat)`
+
+* `centerLeft(_ leftOffset: CGFloat)`
+* `center(_ offset: CGFloat)`
+* `centerRight(_ rightOffset offset: CGFloat)`
+
+* `bottomLeft(_ offset: CGFloat)`
+* `bottomCenter(_ bottomOffset: CGFloat)`
+* `bottomRight(_ offset: CGFloat)`
+
+For example, to position a view at the top left corner with a top and left margin of 10 pixels:
+
+```
+   view.pin.topLeft(10)
+```
+
+#### Other change
+Cleanup the interface by using default value parameters.
+
+* Added by [Luc Dion](https://github.com/lucdion) in Pull Request [#163](https://github.com/layoutBox/PinLayout/pull/163) 
+
+
 ## [1.7.10](https://github.com/layoutBox/PinLayout/releases/tag/1.7.10)
 Released on 2018-07-17
 

--- a/PinLayout.podspec
+++ b/PinLayout.podspec
@@ -8,9 +8,9 @@
 
 Pod::Spec.new do |spec|
   spec.name          = "PinLayout"
-  spec.version       = "1.7.10"
-  spec.summary       = "Fast Swift Views layouting without auto layout. No magic, pure code, full control and blazing fast. [iOS/macOS/tvOS]"
-  spec.description   = "Fast Swift Views layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable. [iOS/macOS/tvOS]"
+  spec.version       = "1.7.11"
+  spec.summary       = "Fast Swift Views layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable. [iOS/macOS/tvOS/CALayer]"
+  spec.description   = "Fast Swift Views layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable. [iOS/macOS/tvOS/CALayer]"
   spec.homepage      = "https://github.com/layoutBox/PinLayout"
   spec.license       = "MIT license"
   spec.author        = { "Luc Dion" => "luc_dion@yahoo.com" }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Nimble (7.0.3)
-  - PinLayout (1.7.9)
+  - PinLayout (1.7.11)
   - Quick (1.2.0)
   - Reveal-SDK (16)
   - SwiftLint (0.25.1)
@@ -13,7 +13,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Nimble
     - Quick
     - Reveal-SDK
@@ -25,11 +25,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Nimble: 7f5a9c447a33002645a071bddafbfb24ea70e0ac
-  PinLayout: 831bd290944681da6e02c2017f25601db55535e9
+  PinLayout: 90c26ecc9504e35c6569a65d78dc50853d96f08c
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   Reveal-SDK: ed36bdbb3cbf90b94ae5da0dbcb3c7ae6738c51f
   SwiftLint: ce933681be10c3266e82576dad676fa815a602e9
 
 PODFILE CHECKSUM: 62618887f8155abc1ed3348d9b676cf6915137e2
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.5.0

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Extremely Fast views layouting without auto layout. No magic, pure code, full co
   * [Width, height and size](#width_height_size)
   * [Adjusting size](#adjusting_size)
   * [minWidth, maxWidth, minHeight, maxHeight](#minmax_width_height_size)
-  * [Aspect Ratio](#aspect_ratio)
   * [Margins](#margins)
+  * [Aspect Ratio](#aspect_ratio)
   * [safeAreaInsets support](#safeAreaInsets)
   * [WrapContent](#wrapContent)
   * [justify, align](#justify_align)
@@ -222,34 +222,34 @@ Another shorter possible solution using `all()`:
 
 The following methods are used to position a view’s edge relative to its superview edges. 
 
-Note that the margin parameter in the following methods can be either positive and negative. In general cases positive values are used.
+:pushpin: The offset/margin parameter in the following methods can be either positive and negative. In general cases positive values are used.
 
-* **`top(_ margin: CGFloat)`** / **`top(_ margin: Percent)`** /  **`top()`** / **`top(_ margin: UIEdgeInsets)`**  
-Position the top edge. The margin specifies the top edge distance from the superview's top edge in pixels (or in percentage of its superview's height). `top()` is similar to calling `top(0)`, it position the view top edge directly on its superview top edge. `top(:UIEdgeInsets)` use the `UIEdgeInsets.top` property, is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+* **`top(_ offset: CGFloat)`** / **`top(_ offset: Percent)`** /  **`top()`** / **`top(_ margin: UIEdgeInsets)`**  
+Position the top edge. The offset specifies the top edge distance from the superview's top edge in pixels (or in percentage of its superview's height). `top()` is similar to calling `top(0)`, it position the view top edge directly on its superview top edge. `top(:UIEdgeInsets)` use the `UIEdgeInsets.top` property, is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
 
-* **`bottom(_ margin: CGFloat)`** / **`bottom(_ margin: Percent)`** / **`bottom()`** / **`bottom(_ margin: UIEdgeInsets)`**   
-Position the bottom edge. The margin specifies the bottom edge **distance from the superview's bottom edge** in pixels (or in percentage of its superview's height). `bottom()` is similar to calling `bottom(0)`, it position the view bottom edge directly on its superview top edge. `bottom(:UIEdgeInsets)` use the `UIEdgeInsets.bottom` property, it is is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+* **`bottom(_ offset: CGFloat)`** / **`bottom(_ offset: Percent)`** / **`bottom()`** / **`bottom(_ margin: UIEdgeInsets)`**   
+Position the bottom edge. The offset specifies the bottom edge **distance from the superview's bottom edge** in pixels (or in percentage of its superview's height). `bottom()` is similar to calling `bottom(0)`, it position the view bottom edge directly on its superview top edge. `bottom(:UIEdgeInsets)` use the `UIEdgeInsets.bottom` property, it is is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
 
-* **`left(_ margin: CGFloat)`** / **`left(_ margin: Percent)`** / **`left()`** / **`left(_ margin: UIEdgeInsets)`**   
-Position the left edge. The margin specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width). `left()` is similar to calling `left(0)`, it position the view left edge directly on its superview left edge. `left(:UIEdgeInsets)` use the `UIEdgeInsets.left` property, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+* **`left(_ offset: CGFloat)`** / **`left(_ offset: Percent)`** / **`left()`** / **`left(_ margin: UIEdgeInsets)`**   
+Position the left edge. The offset specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width). `left()` is similar to calling `left(0)`, it position the view left edge directly on its superview left edge. `left(:UIEdgeInsets)` use the `UIEdgeInsets.left` property, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
 
-* **`right(_ margin: CGFloat)`** / **`right(_ margin: Percent)`** / **`right()`** / **`right(_ margin: UIEdgeInsets)`**   
-Position the right edge. The margin specifies the right edge **distance from the superview's right edge** in pixels (or in percentage of its superview's width). `right()` is similar to calling `right(0)`, it position the view right edge directly on its superview right edge. `right(:UIEdgeInsets)` use the `UIEdgeInsets. right` property, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+* **`right(_ offset: CGFloat)`** / **`right(_ offset: Percent)`** / **`right()`** / **`right(_ margin: UIEdgeInsets)`**   
+Position the right edge. The offset specifies the right edge **distance from the superview's right edge** in pixels (or in percentage of its superview's width). `right()` is similar to calling `right(0)`, it position the view right edge directly on its superview right edge. `right(:UIEdgeInsets)` use the `UIEdgeInsets. right` property, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
 
-* **`vCenter(_ margin: CGFloat)`** / **`vCenter(_ margin: Percent)`** / **`vCenter()`**  
-Position the vertical center (center.y). The margin specifies the distance vertically of the view's center related to the superview's center in pixels (or in percentage of its superview's height). A positive margin move the view down and a negative value move it up relative to the superview's center. `vCenter()` is similar to calling `vCenter(0)`, it position vertically the view's center directly on its superview vertical center.
+* **`vCenter(_ offset: CGFloat)`** / **`vCenter(_ offset: Percent)`** / **`vCenter()`**  
+Position the vertical center (center.y). The offset specifies the distance vertically of the view's center related to the superview's center in pixels (or in percentage of its superview's height). A positive offset move the view down and a negative value move it up relative to the superview's center. `vCenter()` is similar to calling `vCenter(0)`, it position vertically the view's center directly on its superview vertical center.
 
-* **`hCenter(_ margin: CGFloat)`** / **`hCenter(_ margin: Percent)`** / **`hCenter()`**  
-Position the horizontal center (center.x). The margin specifies the distance horizontally of the view's center related to the superview's center in pixels (or in percentage of its superview's width). A positive value move the view to the right and a negative value move it to the left relative to the superview's center. `hCenter()` is similar to calling `hCenter(0)`, it position horizontally the view's center directly on its superview horizontal center. 
+* **`hCenter(_ offset: CGFloat)`** / **`hCenter(_ offset: Percent)`** / **`hCenter()`**  
+Position the horizontal center (center.x). The offset specifies the distance horizontally of the view's center related to the superview's center in pixels (or in percentage of its superview's width). A positive offset move the view to the right and a negative offset move it to the left relative to the superview's center. `hCenter()` is similar to calling `hCenter(0)`, it position horizontally the view's center directly on its superview horizontal center. 
 
 ##### Methods supporting LTR (left-to-right) and RTL (right-to-left) languages.
 
-* **`start(_ margin: CGFloat)`** / **`start(_ margin: Percent)`** / **`start()`** / **`start(_ margin: UIEdgeInsets)`** :left_right_arrow:  
-Position the left or right edge depending of the LTR language direction. In LTR direction the margin specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width). In RTL direction the margin specifies the right edge distance from the superview's right edge in pixels (or in percentage of its superview's width).  
+* **`start(_ offset: CGFloat)`** / **`start(_ offset: Percent)`** / **`start()`** / **`start(_ margin: UIEdgeInsets)`** :left_right_arrow:  
+Position the left or right edge depending of the LTR language direction. In LTR direction the offset specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width). In RTL direction the offset specifies the right edge distance from the superview's right edge in pixels (or in percentage of its superview's width).  
 `start()` is similar to calling `start(0)`. `start(:UIEdgeInsets)` use the `UIEdgeInsets.left` property in LTR direction and `UIEdgeInsets.right` in RTL direction, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
 
-* **`end(_ margin: CGFloat)`** / **`end(_ margin: Percent)`** / **`end()`** / **`end(_ margin: UIEdgeInsets)`** :left_right_arrow:  
-Position the left or right edge depending of the LTR language direction. In LTR direction the value specifies the right edge distance from the superview's right edge in pixels (or in percentage of its superview's width). In RTL direction the value specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width).  `end()` is similar to calling `end(0)`. `end(:UIEdgeInsets)` use the `UIEdgeInsets.right` property in LTR direction and `UIEdgeInsets.left` in RTL direction, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+* **`end(_ offset: CGFloat)`** / **`end(_ offset: Percent)`** / **`end()`** / **`end(_ margin: UIEdgeInsets)`** :left_right_arrow:  
+Position the left or right edge depending of the LTR language direction. In LTR direction the offset specifies the right edge distance from the superview's right edge in pixels (or in percentage of its superview's width). In RTL direction the offset specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width).  `end()` is similar to calling `end(0)`. `end(:UIEdgeInsets)` use the `UIEdgeInsets.right` property in LTR direction and `UIEdgeInsets.left` in RTL direction, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
 
 <a name="pin_multiple_edges"></a>
 **Methods pinning multiple edges**:
@@ -309,59 +309,61 @@ This is equivalent to:
 ```
 **Methods:**
 
-* **`topLeft(_ margin: CGFloat)`** / **`topLeft()`**  
-Position the top and left edges. The margin specifies the distance from their superview's corresponding edges in pixels. `topLeft()` is similar to calling `topLeft(0)`.
+:pushpin: The offset parameter in the following methods can be either positive and negative. In general cases positive values are used.
 
-* **`topCenter(_ marginTop: CGFloat)`** / **`topCenter()`**  
-Position the top and horizontal center (center.x). The margin specifies the top edge distance from the superview's top edge in pixels. `topCenter()` is similar to calling `topCenter(0)`.
+* **`topLeft(_ offset: CGFloat)`** / **`topLeft()`**  
+Position the top and left edges. The offset specifies the distance from their superview's corresponding edges in pixels. `topLeft()` is similar to calling `topLeft(0)`.
 
-* **`topRight(_ margin: CGFloat)`** / **`topRight()`**  
-Position the top and right edges. The margin specifies the distance from their superview's corresponding edges in pixels. `topRight()` is similar to calling `topRight(0)`.
+* **`topCenter(_ topOffset: CGFloat)`** / **`topCenter()`**  
+Position the top and horizontal center (center.x). The offset specifies the top edge distance from the superview's top edge in pixels. `topCenter()` is similar to calling `topCenter(0)`.
 
-
-* **`centerLeft(_ marginLeft: CGFloat)`** / **`centerLeft()`**  
-Position the vertical center (center.y) and the left edge. The margin specifies the left edge distance from the superview's left edge in pixels. `centerLeft()` is similar to calling `centerLeft(0)`.
-
-* **`center(_ margin: CGFloat)`** / **`center()`**  
-Position the horizontal and vertical center (center.y). The margin specify an offset from the superview's center in pixels. `center()` is similar to calling `center(0)`.
-
-* **`centerRight(_ marginRight: CGFloat)`** / **`centerRight()`**  
-Position the vertical center (center.y) and the right edge. The margin specifies the right edge distance from the superview's right edge in pixels. `centerRight()` is similar to calling `centerRight(0)`.
+* **`topRight(_ offset: CGFloat)`** / **`topRight()`**  
+Position the top and right edges. The offset specifies the distance from their superview's corresponding edges in pixels. `topRight()` is similar to calling `topRight(0)`.
 
 
-* **`bottomLeft(_ margin: CGFloat)`** / **`bottomLeft()`**  
-Position the bottom and left edges. The margin specifies the distance from their superview's corresponding edges in pixels. `bottomLeft()` is similar to calling `bottomLeft(0)`.
+* **`centerLeft(_ leftOffset: CGFloat)`** / **`centerLeft()`**  
+Position the vertical center (center.y) and the left edge. The offset specifies the left edge distance from the superview's left edge in pixels. `centerLeft()` is similar to calling `centerLeft(0)`.
 
-* **`bottomCenter(_ marginBottom: CGFloat)`** / **`bottomCenter()`**  
-Position the bottom and horizontal center (center.x). The margin specifies the bottom edge distance from the superview's bottom edge in pixels. `bottomCenter()` is similar to calling `bottomCenter(0)`.
+* **`center(_ offset: CGFloat)`** / **`center()`**  
+Position the horizontal and vertical center (center.y). The offset specifies an offset from the superview's center in pixels. `center()` is similar to calling `center(0)`.
 
-* **`bottomRight(_ margin: CGFloat)`** / **`bottomRight()`**  
-Position the bottom and right edges. The margin specifies the distance from their superview's corresponding edges in pixels. `bottomRight()` is similar to calling `bottomRight(0)`.
+* **`centerRight(_ rightOffset: CGFloat)`** / **`centerRight()`**  
+Position the vertical center (center.y) and the right edge. The offset specifies the right edge distance from the superview's right edge in pixels. `centerRight()` is similar to calling `centerRight(0)`.
+
+
+* **`bottomLeft(_ offset: CGFloat)`** / **`bottomLeft()`**  
+Position the bottom and left edges. The offset specifies the distance from their superview's corresponding edges in pixels. `bottomLeft()` is similar to calling `bottomLeft(0)`.
+
+* **`bottomCenter(_ bottomOffset: CGFloat)`** / **`bottomCenter()`**  
+Position the bottom and horizontal center (center.x). The offset specifies the bottom edge distance from the superview's bottom edge in pixels. `bottomCenter()` is similar to calling `bottomCenter(0)`.
+
+* **`bottomRight(_ offset: CGFloat)`** / **`bottomRight()`**  
+Position the bottom and right edges. The offset specifies the distance from their superview's corresponding edges in pixels. `bottomRight()` is similar to calling `bottomRight(0)`.
 
 
 ##### Methods supporting LTR (left-to-right) and RTL (right-to-left) languages.
 
-* **`topStart(_ margin: CGFloat)`** / **`topStart()`** :left_right_arrow:  
+* **`topStart(_ offset: CGFloat)`** / **`topStart()`** :left_right_arrow:  
 In LTR direction position the top and left edges.
 In RTL direction position the top and right edges.
 
-* **`topEnd(_ margin: CGFloat)`** / **`topEnd()`** :left_right_arrow:  
+* **`topEnd(_ offset: CGFloat)`** / **`topEnd()`** :left_right_arrow:  
 In LTR direction position the top and right edges.
 In RTL direction position the top and left edges.
 
-* **`bottomStart(_ margin: CGFloat)`** / **`bottomStart()`** :left_right_arrow:  
+* **`bottomStart(_ offset: CGFloat)`** / **`bottomStart()`** :left_right_arrow:  
 In LTR direction position the bottom and left edges.
 In RTL direction position the bottom and right edges.
 
-* **`bottomEnd(_ margin: CGFloat)`** / **`bottomEnd()`** :left_right_arrow:  
+* **`bottomEnd(_ offset: CGFloat)`** / **`bottomEnd()`** :left_right_arrow:  
 In LTR direction position the bottom and right edges.
 In RTL direction position the bottom and left edges.
 
-* **`centerStart(_ margin: CGFloat)`** / **`centerStart()`** :left_right_arrow:  
+* **`centerStart(_ offset: CGFloat)`** / **`centerStart()`** :left_right_arrow:  
 In LTR direction position the vertical center (center.y) and the left edge.
 In RTL direction position the vertical center (center.y) and the right edge.
 
-* **`centerEnd(_ margin: CGFloat)`** / **`centerEnd()`** :left_right_arrow:  
+* **`centerEnd(_ offset: CGFloat)`** / **`centerEnd()`** :left_right_arrow:  
 In LTR direction position the vertical center (center.y) and the right edge.
 In RTL direction position the vertical center (center.y) and the left edge.
 
@@ -885,49 +887,6 @@ This is an equivalent solutions using the `justify()` method. This method is exp
 
 <br/>
 
-
-<a name="aspect_ratio"></a>
-## Aspect Ratio 
-Set the view aspect ratio. 
-AspectRatio solves the problem of knowing one dimension of an element and an aspect ratio, this is particularly useful for images. 
-     
-AspectRatio is applied only if a single dimension (either width or height) can be determined, in that case the aspect ratio will be used to compute the other dimension.
-
-* AspectRatio is defined as the ratio between the width and the height (width / height).
-* An aspect ratio of 2 means the width is twice the size of the height.
-* AspectRatio respects the min (minWidth/minHeight) and the max (maxWidth/maxHeight) 
- dimensions of an item.
-     
-**Methods:**
-
-* **`aspectRatio(_ ratio: CGFloat)`**:  
-Set the view aspect ratio using a CGFloat. AspectRatio is defined as the ratio between the width and the height (width / height). 
-
-* **`aspectRatio(of view: UIView)`**:  
-Set the view aspect ratio using another UIView's aspect ratio.      
-
-* **`aspectRatio()`**:  
-If the layouted view is an UIImageView, this method will set the aspectRatio using the UIImageView's image dimension. For other types of views, this method as no impact.
-     
-###### Usage examples:
-```swift
-	aView.pin.left().width(100%).aspectRatio(2)
-	imageView.pin.left().width(200).aspectRatio()
-```
-
-###### Example:
-This example layout an UIImageView at the top and center it horizontally, it also adjust its width to 50%. The view’s height will be adjusted automatically using the image aspect ratio.
-
-<img src="docs/pinlayout_example_aspectratio.png" width="540"/>
-
-
-```swift
-   imageView.pin.top().hCenter().width(50%).aspectRatio()
-```
-
-
-</br>
-
 <a name="margins"></a>
 ## Margins 
 
@@ -1099,6 +1058,49 @@ NOTE: In that in that particular situation, the same results could have been ach
 ```
 
 </br>
+
+
+<a name="aspect_ratio"></a>
+## Aspect Ratio 
+Set the view aspect ratio. 
+AspectRatio solves the problem of knowing one dimension of an element and an aspect ratio, this is particularly useful for images. 
+     
+AspectRatio is applied only if a single dimension (either width or height) can be determined, in that case the aspect ratio will be used to compute the other dimension.
+
+* AspectRatio is defined as the ratio between the width and the height (width / height).
+* An aspect ratio of 2 means the width is twice the size of the height.
+* AspectRatio respects the min (minWidth/minHeight) and the max (maxWidth/maxHeight) 
+ dimensions of an item.
+     
+**Methods:**
+
+* **`aspectRatio(_ ratio: CGFloat)`**:  
+Set the view aspect ratio using a CGFloat. AspectRatio is defined as the ratio between the width and the height (width / height). 
+
+* **`aspectRatio(of view: UIView)`**:  
+Set the view aspect ratio using another UIView's aspect ratio.      
+
+* **`aspectRatio()`**:  
+If the layouted view is an UIImageView, this method will set the aspectRatio using the UIImageView's image dimension. For other types of views, this method as no impact.
+     
+###### Usage examples:
+```swift
+	aView.pin.left().width(100%).aspectRatio(2)
+	imageView.pin.left().width(200).aspectRatio()
+```
+
+###### Example:
+This example layout an UIImageView at the top and center it horizontally, it also adjust its width to 50%. The view’s height will be adjusted automatically using the image aspect ratio.
+
+<img src="docs/pinlayout_example_aspectratio.png" width="540"/>
+
+
+```swift
+   imageView.pin.top().hCenter().width(50%).aspectRatio()
+```
+
+</br>
+
 
 <a name="safeAreaInsets"></a>
 ## UIKit safeAreaInsets support 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ Extremely Fast views layouting without auto layout. No magic, pure code, full co
 * [Performance](#performance)
 * [Documentation](#documentation)
   * [Right to left languages (RTL) support](#rtl_support)
-  * [Layout using distances from superview’s edges](#distance_from_superview_edge) 
+  * [Edges layout](#layout_edges) 
+  * [Relative Edges layout](#relative_edges_layout)
+	  * [Relative Edges with alignment layout](#relative_edges_layout_w_alignment)
   * [Edges](#edges)
   * [Anchors](#anchors)
-  * [Relative positioning](#relative_positioning)
   * [Width, height and size](#width_height_size)
   * [Adjusting size](#adjusting_size)
   * [minWidth, maxWidth, minHeight, maxHeight](#minmax_width_height_size)
@@ -196,75 +197,10 @@ PinLayout supports left-to-right (LTR) and right-to-left (RTL) languages. [See h
 <br/>
 
 
-<a name="distance_from_superview_edge"></a>
-## Layout using distances from superview’s edges 
+<a name="layout_edges"></a>
+## Edges layout
 
 PinLayout can position a view’s edge relative to its superview edges.
-
-**Methods**:
-
-* **`top(:CGFloat)`** / **`top(:Percent)`** /  **`top()`** / **`top(:UIEdgeInsets)`**  
-The value specifies the top edge distance from the superview's top edge in pixels (or in percentage of its superview's height). `top()` is similar to calling `top(0)`, it position the view top edge directly on its superview top edge. `top(:UIEdgeInsets)` use the `UIEdgeInsets.top` property, is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
-
-* **`bottom(:CGFloat)`** / **`bottom(:Percent)`** / **`bottom()`** / **`bottom(:UIEdgeInsets)`**   
-The value specifies the bottom edge **distance from the superview's bottom edge** in pixels (or in percentage of its superview's height). `bottom()` is similar to calling `bottom(0)`, it position the view bottom edge directly on its superview top edge. `bottom(:UIEdgeInsets)` use the `UIEdgeInsets.bottom` property, it is is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
-
-* **`left(:CGFloat)`** / **`left(:Percent)`** / **`left()`** / **`left(:UIEdgeInsets)`**   
-The value specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width). `left()` is similar to calling `left(0)`, it position the view left edge directly on its superview left edge. `left(:UIEdgeInsets)` use the `UIEdgeInsets.left` property, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
-
-* **`right(:CGFloat)`** / **`right(:Percent)`** / **`right()`** / **`right(:UIEdgeInsets)`**   
-The value specifies the right edge **distance from the superview's right edge** in pixels (or in percentage of its superview's width). `right()` is similar to calling `right(0)`, it position the view right edge directly on its superview right edge. `right(:UIEdgeInsets)` use the `UIEdgeInsets. right` property, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
-
-* **`vCenter(:CGFloat)`** / **`vCenter(:Percent)`** / **`vCenter()`**  
-The value specifies the distance vertically of the view's center related to the superview's center in pixels (or in percentage of its superview's height). A positive value move the view down and a negative value move it up relative to the superview's center. `vCenter()` is similar to calling `vCenter(0)`, it position vertically the view's center directly on its superview vertical center.
-
-* **`hCenter(:CGFloat)`** / **`hCenter(:Percent)`** / **`hCenter()`**  
-The value specifies the distance horizontally of the view's center related to the superview's center in pixels (or in percentage of its superview's width). A positive value move the view to the right and a negative value move it to the left relative to the superview's center. `hCenter()` is similar to calling `hCenter(0)`, it position horizontally the view's center directly on its superview horizontal center. 
-
-* **`start(:CGFloat)`** / **`start(:Percent)`** / **`start()`** / **`start(:UIEdgeInsets)`** :left_right_arrow:  
-In LTR direction the value specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width).   
-In RTL direction the value specifies the right edge distance from the superview's right edge in pixels (or in percentage of its superview's width).  
-`start()` is similar to calling `start(0)`. `start(:UIEdgeInsets)` use the `UIEdgeInsets.left` property in LTR direction and `UIEdgeInsets.right` in RTL direction, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
-
-* **`end(:CGFloat)`** / **`end(:Percent)`** / **`end()`** / **`end(:UIEdgeInsets)`** :left_right_arrow:  
-In LTR direction the value specifies the right edge distance from the superview's right edge in pixels (or in percentage of its superview's width).  
-In RTL direction the value specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width).  `end()` is similar to calling `end(0)`. `end(:UIEdgeInsets)` use the `UIEdgeInsets.right` property in LTR direction and `UIEdgeInsets.left` in RTL direction, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
-
-<a name="pin_multiple_edges"></a>
-**Methods pinning multiple edges**:
-
-* **`all(:CGFloat)`** / **`all(:UIEdgeInsets)`** / **`all()`**  
-The value/insets specifies the **top, bottom, left and right edges** distance from the superview's corresponding edge in pixels. Similar to calling `view.top(value).bottom(value).left(value).right(value)`.  
-`all()` is similar to calling `all(0)`.  
-`all(:UIEdgeInsets)` is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
-
-* **`horizontally(:CGFloat)`** / **`horizontally(:Percent)`** /  
-**`horizontally(:UIEdgeInsets)`** / **`horizontally()`**  
-The value specifies the **left and right edges** on its superview's corresponding edges in pixels (or in percentage of its superview's width).  
-`horizontally()` is similar to calling `horizontally(0)`.  
-`horizontally(:UIEdgeInsets)` use the UIEdgeInsets's left and right value to pin left and right edges.
-
-* **`vertically(:CGFloat)`** / **`vertically(:Percent)`**   
-**`vertically(:UIEdgeInsets)`** / **`vertically()`**  
-The value specifies the **top and bottom edges** on its superview's corresponding edges in pixels (or in percentage of its superview's height).  
-`vertically()` is similar to calling `vertically(0)`.  
-`vertically(:UIEdgeInsets)` use the UIEdgeInsets's top and bottom value to pin top and bottom edges.
-
-
-
-###### Usage Examples:
-
-```swift
-   view.pin.top(20).bottom(20)   // The view has a top margin and a bottom margin of 20 pixels 
-   view.pin.top().left()         // The view is pinned directly on its parent top and left edge
-   view.pin.all()                // The view fill completely its parent (horizontally and vertically)
-   view.pin.all(pin.safeArea)    // The view fill completely its parent safeArea 
-   view.pin.top(25%).hCenter()   // The view is centered horizontally with a top margin of 25%
-   view.pin.left(12).vCenter()   // The view is centered vertically
-   view.pin.start(20).end(20)    // Support right-to-left languages.
-   view.pin.horizontally(20)     // The view is filling its parent width with a left and right margin.
-   view.pin.top().horizontally() // The view is pinned at the top edge of its parent and fill it horizontally.
-```
 
 ###### Example:
 This example layout the view A to fit its superview frame with a margin of 10 pixels. It pins the top, left, bottom and right edges.
@@ -282,7 +218,339 @@ Another shorter possible solution using `all()`:
     view.pin.all(10)
 ```
 
+**Methods**:
+
+The following methods are used to position a view’s edge relative to its superview edges. 
+
+Note that the margin parameter in the following methods can be either positive and negative. In general cases positive values are used.
+
+* **`top(_ margin: CGFloat)`** / **`top(_ margin: Percent)`** /  **`top()`** / **`top(_ margin: UIEdgeInsets)`**  
+Position the top edge. The margin specifies the top edge distance from the superview's top edge in pixels (or in percentage of its superview's height). `top()` is similar to calling `top(0)`, it position the view top edge directly on its superview top edge. `top(:UIEdgeInsets)` use the `UIEdgeInsets.top` property, is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+
+* **`bottom(_ margin: CGFloat)`** / **`bottom(_ margin: Percent)`** / **`bottom()`** / **`bottom(_ margin: UIEdgeInsets)`**   
+Position the bottom edge. The margin specifies the bottom edge **distance from the superview's bottom edge** in pixels (or in percentage of its superview's height). `bottom()` is similar to calling `bottom(0)`, it position the view bottom edge directly on its superview top edge. `bottom(:UIEdgeInsets)` use the `UIEdgeInsets.bottom` property, it is is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+
+* **`left(_ margin: CGFloat)`** / **`left(_ margin: Percent)`** / **`left()`** / **`left(_ margin: UIEdgeInsets)`**   
+Position the left edge. The margin specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width). `left()` is similar to calling `left(0)`, it position the view left edge directly on its superview left edge. `left(:UIEdgeInsets)` use the `UIEdgeInsets.left` property, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+
+* **`right(_ margin: CGFloat)`** / **`right(_ margin: Percent)`** / **`right()`** / **`right(_ margin: UIEdgeInsets)`**   
+Position the right edge. The margin specifies the right edge **distance from the superview's right edge** in pixels (or in percentage of its superview's width). `right()` is similar to calling `right(0)`, it position the view right edge directly on its superview right edge. `right(:UIEdgeInsets)` use the `UIEdgeInsets. right` property, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+
+* **`vCenter(_ margin: CGFloat)`** / **`vCenter(_ margin: Percent)`** / **`vCenter()`**  
+Position the vertical center (center.y). The margin specifies the distance vertically of the view's center related to the superview's center in pixels (or in percentage of its superview's height). A positive margin move the view down and a negative value move it up relative to the superview's center. `vCenter()` is similar to calling `vCenter(0)`, it position vertically the view's center directly on its superview vertical center.
+
+* **`hCenter(_ margin: CGFloat)`** / **`hCenter(_ margin: Percent)`** / **`hCenter()`**  
+Position the horizontal center (center.x). The margin specifies the distance horizontally of the view's center related to the superview's center in pixels (or in percentage of its superview's width). A positive value move the view to the right and a negative value move it to the left relative to the superview's center. `hCenter()` is similar to calling `hCenter(0)`, it position horizontally the view's center directly on its superview horizontal center. 
+
+##### Methods supporting LTR (left-to-right) and RTL (right-to-left) languages.
+
+* **`start(_ margin: CGFloat)`** / **`start(_ margin: Percent)`** / **`start()`** / **`start(_ margin: UIEdgeInsets)`** :left_right_arrow:  
+Position the left or right edge depending of the LTR language direction. In LTR direction the margin specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width). In RTL direction the margin specifies the right edge distance from the superview's right edge in pixels (or in percentage of its superview's width).  
+`start()` is similar to calling `start(0)`. `start(:UIEdgeInsets)` use the `UIEdgeInsets.left` property in LTR direction and `UIEdgeInsets.right` in RTL direction, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+
+* **`end(_ margin: CGFloat)`** / **`end(_ margin: Percent)`** / **`end()`** / **`end(_ margin: UIEdgeInsets)`** :left_right_arrow:  
+Position the left or right edge depending of the LTR language direction. In LTR direction the value specifies the right edge distance from the superview's right edge in pixels (or in percentage of its superview's width). In RTL direction the value specifies the left edge distance from the superview's left edge in pixels (or in percentage of its superview's width).  `end()` is similar to calling `end(0)`. `end(:UIEdgeInsets)` use the `UIEdgeInsets.right` property in LTR direction and `UIEdgeInsets.left` in RTL direction, it is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+
+<a name="pin_multiple_edges"></a>
+**Methods pinning multiple edges**:
+
+* **`all(_ margin: CGFloat)`** / **`all()`** / **`all(_ margin: UIEdgeInsets)`**   
+Position the top, left, bottom and right edges. The margin specifies the **top, bottom, left and right edges** distance from the superview's corresponding edge in pixels. Similar to calling `view.top(value).bottom(value).left(value).right(value)`.  
+`all()` is similar to calling `all(0)`.  
+`all(:UIEdgeInsets)` is particularly useful with [`UIView.pin.safeArea`](#safeAreaInsets) or `UIView.safeAreaInsets`.
+
+* **`horizontally(_ margin: CGFloat)`** / **`horizontally(_ margin: Percent)`** / **`horizontally()`** / **`horizontally(_ margin: UIEdgeInsets)`**   
+Position the left and right edges. The margin specifies the **left and right edges** distance from its superview's corresponding edges in pixels (or in percentage of its superview's width).  
+`horizontally()` is similar to calling `horizontally(0)`.  
+`horizontally(:UIEdgeInsets)` use the UIEdgeInsets's left and right value to pin left and right edges.
+
+* **`vertically(_ margin: CGFloat)`** / **`vertically(_ margin: Percent)`** / **`vertically()`** / **`vertically(_ margin: UIEdgeInsets)`**  
+Position the top and bottom edges. The margin specifies the **top and bottom edges** distance from on its superview's corresponding edges in pixels (or in percentage of its superview's height).  
+`vertically()` is similar to calling `vertically(0)`.  
+`vertically(:UIEdgeInsets)` use the UIEdgeInsets's top and bottom value to pin top and bottom edges.
+
+
+###### Usage Examples:
+
+```swift
+   view.pin.top(20).bottom(20)   // The view has a top margin and a bottom margin of 20 pixels 
+   view.pin.top().left()         // The view is pinned directly on its parent top and left edge
+   view.pin.all()                // The view fill completely its parent (horizontally and vertically)
+   view.pin.all(pin.safeArea)    // The view fill completely its parent safeArea 
+   view.pin.top(25%).hCenter()   // The view is centered horizontally with a top margin of 25%
+   view.pin.left(12).vCenter()   // The view is centered vertically
+   view.pin.start(20).end(20)    // Support right-to-left languages.
+   view.pin.horizontally(20)     // The view is filling its parent width with a left and right margin.
+   view.pin.top().horizontally() // The view is pinned at the top edge of its parent and fill it horizontally.
+```
+
 <br/>
+
+#### Layout multiple edges relative to superview
+
+This section describe methods that are similar to methods describe in the previous section [Edges layout](#layout_edges), except that they position 2 edges simultaneously. They can be used as shortcuts to set 2 consecutive edges.
+
+<img src="docs/pinlayout-anchors.png" width="400"/>
+
+###### Example:
+This example position the view’s on the top-right corner of its superview’s topRight and set its size to 100 pixels.
+
+<img src="docs/images/pinlayout_example_topRight.png" width="600"/>
+
+
+```swift
+	viewA.pin.topRight().size(100)
+``` 
+
+This is equivalent to:
+
+```swift
+	viewA.pin.top().right().size(100)
+```
+**Methods:**
+
+* **`topLeft(_ margin: CGFloat)`** / **`topLeft()`**  
+Position the top and left edges. The margin specifies the distance from their superview's corresponding edges in pixels. `topLeft()` is similar to calling `topLeft(0)`.
+
+* **`topCenter(_ marginTop: CGFloat)`** / **`topCenter()`**  
+Position the top and horizontal center (center.x). The margin specifies the top edge distance from the superview's top edge in pixels. `topCenter()` is similar to calling `topCenter(0)`.
+
+* **`topRight(_ margin: CGFloat)`** / **`topRight()`**  
+Position the top and right edges. The margin specifies the distance from their superview's corresponding edges in pixels. `topRight()` is similar to calling `topRight(0)`.
+
+
+* **`centerLeft(_ marginLeft: CGFloat)`** / **`centerLeft()`**  
+Position the vertical center (center.y) and the left edge. The margin specifies the left edge distance from the superview's left edge in pixels. `centerLeft()` is similar to calling `centerLeft(0)`.
+
+* **`center(_ margin: CGFloat)`** / **`center()`**  
+Position the horizontal and vertical center (center.y). The margin specify an offset from the superview's center in pixels. `center()` is similar to calling `center(0)`.
+
+* **`centerRight(_ marginRight: CGFloat)`** / **`centerRight()`**  
+Position the vertical center (center.y) and the right edge. The margin specifies the right edge distance from the superview's right edge in pixels. `centerRight()` is similar to calling `centerRight(0)`.
+
+
+* **`bottomLeft(_ margin: CGFloat)`** / **`bottomLeft()`**  
+Position the bottom and left edges. The margin specifies the distance from their superview's corresponding edges in pixels. `bottomLeft()` is similar to calling `bottomLeft(0)`.
+
+* **`bottomCenter(_ marginBottom: CGFloat)`** / **`bottomCenter()`**  
+Position the bottom and horizontal center (center.x). The margin specifies the bottom edge distance from the superview's bottom edge in pixels. `bottomCenter()` is similar to calling `bottomCenter(0)`.
+
+* **`bottomRight(_ margin: CGFloat)`** / **`bottomRight()`**  
+Position the bottom and right edges. The margin specifies the distance from their superview's corresponding edges in pixels. `bottomRight()` is similar to calling `bottomRight(0)`.
+
+
+##### Methods supporting LTR (left-to-right) and RTL (right-to-left) languages.
+
+* **`topStart(_ margin: CGFloat)`** / **`topStart()`** :left_right_arrow:  
+In LTR direction position the top and left edges.
+In RTL direction position the top and right edges.
+
+* **`topEnd(_ margin: CGFloat)`** / **`topEnd()`** :left_right_arrow:  
+In LTR direction position the top and right edges.
+In RTL direction position the top and left edges.
+
+* **`bottomStart(_ margin: CGFloat)`** / **`bottomStart()`** :left_right_arrow:  
+In LTR direction position the bottom and left edges.
+In RTL direction position the bottom and right edges.
+
+* **`bottomEnd(_ margin: CGFloat)`** / **`bottomEnd()`** :left_right_arrow:  
+In LTR direction position the bottom and right edges.
+In RTL direction position the bottom and left edges.
+
+* **`centerStart(_ margin: CGFloat)`** / **`centerStart()`** :left_right_arrow:  
+In LTR direction position the vertical center (center.y) and the left edge.
+In RTL direction position the vertical center (center.y) and the right edge.
+
+* **`centerEnd(_ margin: CGFloat)`** / **`centerEnd()`** :left_right_arrow:  
+In LTR direction position the vertical center (center.y) and the right edge.
+In RTL direction position the vertical center (center.y) and the left edge.
+
+<br/>
+
+<a name="relative_edges_layout"></a>
+## Relative Edges layout 
+
+### Layout using edge relative positioning
+
+PinLayout also has methods to position relative to other views. The view can be layouted relative to **one or many relative views**.
+
+**Methods:**
+
+* **`above(of: UIView)`**  / **`above(of: [UIView])`**  
+Position the view above the specified view(s). One or many relative views can be specified. This method position the view’s bottom edge.  
+* **`below(of: UIView)`** / **`below(of: [UIView])`**  
+Position the view below the specified view(s). One or many relative views can be specified. This method position the view’s top edge.  
+* **`before(of: UIView)`** / **`before(of: [UIView])`** :left_right_arrow:  
+In LTR direction the view is positioned at the left of the specified view(s). In RTL direction the view is positioned at the right. One or many relative views can be specified.
+* **`after(of: UIView)`** / **`after(of: [UIView])`**:left_right_arrow:  
+In LTR direction the view is positioned at the right of the specified view(s). In RTL direction the view is positioned at the left. One or many relative views can be specified. 
+* **`left(of: UIView)`** / **`left(of: [UIView])`**  
+Position the view left of the specified view(s). Similar to `before(of:)`. One or many relative views can be specified. This method position the view’s right edge.  
+* **`right(of: UIView)`** / **`right(of: [UIView])`**  
+Position the view right of the specified view(s). Similar to `after(of:)`. One or many relative views can be specified. This method position the view’s left edge.
+
+:pushpin: **Multiple relative views**: If for example a call to `below(of: [...]) specify multiple relative views, the view will be layouted below *ALL* these views. 
+
+:pushpin: These methods **set the position of a view's edge**: top, left, bottom or right. For example `below(of ...)` set the view's top edge, `right(of ...) set the view's left edge, ...
+
+:pushpin: These methods can pin a view’s relative to any views, even if don't have the same direct superview! It works with any views that have at some point the same ancestor. 
+
+###### Usage examples:
+```swift
+	view.pin.after(of: view4).before(of: view1).below(of: view3)
+	view.pin.after(of: view2)
+	view.pin.below(of: [view2, view3, view4])
+```
+
+###### Example:
+The following example will position the view C between the view A and B with margins of 10px using relative positioning methods.
+
+<img src="docs/pinlayout-relative.png" width="600"/>
+
+
+```swift
+	viewC.pin.top().after(of: viewA).before(of: viewB).margin(10)
+```
+This is an equivalent solution using [edges](#edge):
+
+```swift
+	viewC.pin.top().left(to: viewA.edge.right).right(to: viewB.edge.left).margin(10)
+```
+
+This is also an equivalent solution using [Relative Edges and alignment layout](#relative_edges_layout_w_alignment) explained in the next section:
+
+```swift
+	viewC.pin.after(of: viewA, aligned: .top).before(of: viewB, aligned: top).marginHorizontal(10)
+```
+
+
+<br/>
+
+<a name="relative_edges_layout_w_alignment"></a>
+### Layout using Relative Edges and alignment layout 
+
+PinLayout also has methods to position relative to other views but with also the ability to specify the **alignment**. The view can be layouted relative to **one or many relative views**.
+
+
+**Methods:**
+
+* **`above(of: UIView, aligned: HorizontalAlignment)`**  
+**`above(of: [UIView], aligned: HorizontalAlignment)`**  
+Position the view above the specified view(s) and aligned it using the specified HorizontalAlignment. One or many relative views can be specified. This method is similar to pinning one view’s anchor: bottomLeft, bottomCenter or bottomRight.  
+  
+* **`below(of: UIView, aligned: HorizontalAlignment)`**  
+**`below(of: [UIView], aligned: HorizontalAlignment)`**  
+Position the view below the specified view(s) and aligned it using the specified HorizontalAlignment. One or many relative views can be specified. This method is similar to pinning one view’s anchor: topLeft, topCenter or topRight.  
+  
+* **`before(of: UIView, aligned: HorizontalAlignment)`**:left_right_arrow:  
+**`before(of: [UIView], aligned: HorizontalAlignment)`**:left_right_arrow:  
+In LTR direction the view is positioned at the left of the specified view(s). In RTL direction the view is positioned at the right. One or many relative views can be specified. 
+
+* **`after(of: UIView, aligned: HorizontalAlignment)`**:left_right_arrow:  
+**`after(of: [UIView], aligned: HorizontalAlignment)`**:left_right_arrow:  
+In LTR direction the view is positioned at the right of the specified view(s). In RTL direction the view is positioned at the left. One or many relative views can be specified. 
+
+* **`left(of: UIView, aligned: VerticalAlignment)`**  
+**`left(of: [UIView], aligned: HorizontalAlignment)`**  
+Position the view left of the specified view(s) and aligned it using the specified VerticalAlignment. Similar to `before(of:)`. One or many relative views can be specified. This method is similar to pinning one view’s anchor: topRight, centerRight or bottomRight.  
+  
+* **`right(of: UIView, aligned: VerticalAlignment)`**  
+**`right(of: [UIView], aligned: HorizontalAlignment)`**  
+Position the view right of the specified view(s) and aligned it using the specified VerticalAlignment. Similar to `after(of:)`. One or many relative views can be specified. This method is similar to pinning one view’s anchor: topLeft, centerLeft or bottomLeft.
+
+
+**How alignment is applied:**
+
+* **`HorizontalAlignment.left`**: The view's left edge will be aligned to the left most relative view.
+* **`HorizontalAlignment.center`**: The view's hCenter edge will be aligned with the average hCenter of all relative views.
+*  **`HorizontalAlignment.right`**: The view's right edge will be aligned to the right most relative view.
+* **`HorizontalAlignment.start`**:left_right_arrow::  
+In LTR direction the view's left edge will be aligned to the left most relative view.  
+In RTL direction the view's right edge will be aligned to the right most relative view.
+* **`HorizontalAlignment.end`**:left_right_arrow::  
+In LTR direction the view's right edge will be aligned to the right most relative view.  
+In RTL direction the view's left edge will be aligned to the right most relative view.
+*  **`VerticalAlignment.top`**: The view's top edge will be aligned to the top most relative view.
+*  **`VerticalAlignment.center`**: The view's vCenter edge will be aligned with the average vCenter of all relative views.
+*  **`VerticalAlignment.bottom`**: The view's bottom edge will be aligned to the bottom most relative view.
+
+:pushpin: **Multiple relative views**: If for example a call to `below(of: [...], aligned:) specify multiple relative views, the view will be layouted below *ALL* these views. The alignment will be applied using all relative view
+
+:pushpin: These methods **set the position of a view's anchor**: topLeft, topCenter, topRight, centerLeft, .... For example `below(of ..., aligned: .right)` set the view's topRight anchor, `right(of ..., aligned: .center) set the view's centerLeft anchor, ...
+
+:pushpin: These methods **set the position of a view's edge**: top, left, bottom or right. For example `below(of ...)` set the view's top edge, `right(of ...) set the view's left edge, ...
+
+
+###### Usage examples:
+```swift
+	view.pin.above(of: view2, aligned: .left)
+	view.pin.below(of: [view2, view3, view4], aligned: .left)
+	view.pin.after(of: view2, aligned: .top).before(of: view3, aligned: .bottom)
+```
+
+###### Example:
+The following example layout the view B below the view A aligned on its center.
+
+<img src="docs/pinlayout-relative-with-alignment.png" width="600"/>
+
+
+```swift
+	viewB.pin.below(of: viewA, aligned: .center)
+```
+This is an equivalent solution using anchors:
+
+```swift
+	viewB.pin.topCenter(to: viewA.anchor.bottomCenter)
+```
+
+###### Example:
+The following example layout the view A **below the UIImageView and the UILabel**.
+View A should be left aligned to the UIImageView and right aligned to the UILabel, with a top margin of 10 pixels.
+
+<img src="docs/pinlayout-relative-multi.png" width="600"/>
+
+
+```swift
+	a.pin.below(of: [imageView, label], aligned: .left).right(to: label.edge.right).marginTop(10)
+```
+This is an equivalent solutions using other methods:
+
+```swift
+   let maxY = max(imageView.frame.maxY, label.frame.maxY)  // Not so nice
+   a.pin.top(maxY).left(to: imageView.edge.left).right(to: label.edge.right).marginTop(10)
+```
+
+<br/>
+
+
+### Positioning using only visible relative Views 
+
+All PinLayout's relative methods can accept an array of Views (ex: `below(of: [UIView])`). Using these methods its possible to filter the list of relative Views before the list is used by PinLayout.
+
+PinLayout has a filter method called `visible` that can be used to layout a view related to only visible views. This can be really useful when some views may be visible or hidden depending on the situation.
+
+###### Example:
+The following example contains a UISwitch. Below a UITextField that is visible only when the UISwitch is set to ON. And then follow another UITextField. This example use the `visible(views: [UIView]) -> [UIView]` filter method that returns only views with `UIView.isHidden` set to false or `UIView.alpha` greater than 0.
+
+<img src="docs/pinlayout-relative-visible.png" width="600"/>
+
+
+
+```swift
+   formTitleLabel.pin.topCenter().marginTop(margin)
+   nameField.pin.below(of: formTitleLabel).horizontally().height(40).margin(margin)
+        
+   ageSwitch.pin.below(of: nameField).horizontally().height(40).margin(margin)
+   ageField.pin.below(of: ageSwitch).horizontally().height(40).margin(margin)
+       
+   // Layout the Address UITextField below the last visible view, either ageSwitch or ageField.
+   addressField.pin.below(of: visibles([ageSwitch, ageField])).horizontally().height(40).margin(margin)
+``` 
+
+Note that this example is extracted from the **Form** example, see [Examples App](#examples_app)
+
+<br/>
+
 
 <a name="edges"></a>
 ## Edges 
@@ -442,225 +710,6 @@ It is also possible to combine two anchors to pin the position and the size of a
 	viewC.pin.topLeft(to: viewA.anchor.topRight)
 	         .bottomRight(to: viewB.anchor.bottomLeft).marginHorizontal(10)
 ``` 
-
-<br/>
-
-### Layout using superview’s anchors
-
-PinLayout also has a shorter version that pins a view's anchor **directly** on it's corresponding superview’s anchor.
-
-The following methods position the corresponding view's anchor on another view’s anchor.
-
-**Methods:**
-
-* `topLeft()` / `topCenter()` / `topRight()`
-* `topStart()` / `topEnd()` :left_right_arrow:
-* `centerLeft()` / `center()` / `centerRight()`
-* `centerStart()` / `centerEnd()` :left_right_arrow:
-* `bottomLeft()` / `bottomCenter()` / `bottomRight()`
-* `bottomStart()` / `bottomEnd()` :left_right_arrow:
-
-###### Example:
-For example .topRight() will pin the view’s topRight anchor on its superview’s topRight anchor.
-
-<img src="docs/example-superview-anchors.png" width="600"/>
-
-
-```swift
-	viewA.pin.topRight()
-``` 
-
-This is equivalent to:
-
-```swift
-	viewA.pin.topRight(to: superview.anchor.topRight)
-	// OR
-	viewA.pin.top().right()
-```
-
-<br/>
-
-<a name="relative_positioning"></a>
-## Relative positioning 
-
-### Layout using edges relative positioning
-
-PinLayout also has methods to position relative to other views. The view can be layouted relative to **one or many relative views**.
-
-**Methods:**
-
-* **`above(of: UIView)`**  / **`above(of: [UIView])`**  
-Position the view above the specified view(s). One or many relative views can be specified. This method position the view’s bottom edge.  
-* **`below(of: UIView)`** / **`below(of: [UIView])`**  
-Position the view below the specified view(s). One or many relative views can be specified. This method position the view’s top edge.  
-* **`before(of: UIView)`** / **`before(of: [UIView])`** :left_right_arrow:  
-In LTR direction the view is positioned at the left of the specified view(s). In RTL direction the view is positioned at the right. One or many relative views can be specified.
-* **`after(of: UIView)`** / **`after(of: [UIView])`**:left_right_arrow:  
-In LTR direction the view is positioned at the right of the specified view(s). In RTL direction the view is positioned at the left. One or many relative views can be specified. 
-* **`left(of: UIView)`** / **`left(of: [UIView])`**  
-Position the view left of the specified view(s). Similar to `before(of:)`. One or many relative views can be specified. This method position the view’s right edge.  
-* **`right(of: UIView)`** / **`right(of: [UIView])`**  
-Position the view right of the specified view(s). Similar to `after(of:)`. One or many relative views can be specified. This method position the view’s left edge.
-
-:pushpin: **Multiple relative views**: If for example a call to `below(of: [...]) specify multiple relative views, the view will be layouted below *ALL* these views. 
-
-:pushpin: These methods **set the position of a view's edge**: top, left, bottom or right. For example `below(of ...)` set the view's top edge, `right(of ...) set the view's left edge, ...
-
-:pushpin: These methods can pin a view’s relative to any views, even if don't have the same direct superview! It works with any views that have at some point the same ancestor. 
-
-###### Usage examples:
-```swift
-	view.pin.after(of: view4).before(of: view1).below(of: view3)
-	view.pin.after(of: view2)
-	view.pin.below(of: [view2, view3, view4])
-```
-
-###### Example:
-The following example will position the view C between the view A and B with margins of 10px using relative positioning methods.
-
-<img src="docs/pinlayout-relative.png" width="600"/>
-
-
-```swift
-	viewC.pin.top().after(of: viewA).before(of: viewB).margin(10)
-```
-This is an equivalent solution using [edges](#edge):
-
-```swift
-	viewC.pin.top().left(to: viewA.edge.right).right(to: viewB.edge.left).margin(10)
-```
-
-This is also an equivalent solution using [relative positioning and alignment](#relative_positioning_w_alignment) explained in the next section:
-
-```swift
-	viewC.pin.after(of: viewA, aligned: .top).before(of: viewB, aligned: top).marginHorizontal(10)
-```
-
-
-<br/>
-
-<a name="relative_positioning_w_alignment"></a>
-### Layout using relative positioning and alignment 
-
-PinLayout also has methods to position relative to other views but with also the ability to specify the **alignment**. The view can be layouted relative to **one or many relative views**.
-
-
-**Methods:**
-
-* **`above(of: UIView, aligned: HorizontalAlignment)`**  
-**`above(of: [UIView], aligned: HorizontalAlignment)`**  
-Position the view above the specified view(s) and aligned it using the specified HorizontalAlignment. One or many relative views can be specified. This method is similar to pinning one view’s anchor: bottomLeft, bottomCenter or bottomRight.  
-  
-* **`below(of: UIView, aligned: HorizontalAlignment)`**  
-**`below(of: [UIView], aligned: HorizontalAlignment)`**  
-Position the view below the specified view(s) and aligned it using the specified HorizontalAlignment. One or many relative views can be specified. This method is similar to pinning one view’s anchor: topLeft, topCenter or topRight.  
-  
-* **`before(of: UIView, aligned: HorizontalAlignment)`**:left_right_arrow:  
-**`before(of: [UIView], aligned: HorizontalAlignment)`**:left_right_arrow:  
-In LTR direction the view is positioned at the left of the specified view(s). In RTL direction the view is positioned at the right. One or many relative views can be specified. 
-
-* **`after(of: UIView, aligned: HorizontalAlignment)`**:left_right_arrow:  
-**`after(of: [UIView], aligned: HorizontalAlignment)`**:left_right_arrow:  
-In LTR direction the view is positioned at the right of the specified view(s). In RTL direction the view is positioned at the left. One or many relative views can be specified. 
-
-* **`left(of: UIView, aligned: VerticalAlignment)`**  
-**`left(of: [UIView], aligned: HorizontalAlignment)`**  
-Position the view left of the specified view(s) and aligned it using the specified VerticalAlignment. Similar to `before(of:)`. One or many relative views can be specified. This method is similar to pinning one view’s anchor: topRight, centerRight or bottomRight.  
-  
-* **`right(of: UIView, aligned: VerticalAlignment)`**  
-**`right(of: [UIView], aligned: HorizontalAlignment)`**  
-Position the view right of the specified view(s) and aligned it using the specified VerticalAlignment. Similar to `after(of:)`. One or many relative views can be specified. This method is similar to pinning one view’s anchor: topLeft, centerLeft or bottomLeft.
-
-
-**How alignment is applied:**
-
-* **`HorizontalAlignment.left`**: The view's left edge will be aligned to the left most relative view.
-* **`HorizontalAlignment.center`**: The view's hCenter edge will be aligned with the average hCenter of all relative views.
-*  **`HorizontalAlignment.right`**: The view's right edge will be aligned to the right most relative view.
-* **`HorizontalAlignment.start`**:left_right_arrow::  
-In LTR direction the view's left edge will be aligned to the left most relative view.  
-In RTL direction the view's right edge will be aligned to the right most relative view.
-* **`HorizontalAlignment.end`**:left_right_arrow::  
-In LTR direction the view's right edge will be aligned to the right most relative view.  
-In RTL direction the view's left edge will be aligned to the right most relative view.
-*  **`VerticalAlignment.top`**: The view's top edge will be aligned to the top most relative view.
-*  **`VerticalAlignment.center`**: The view's vCenter edge will be aligned with the average vCenter of all relative views.
-*  **`VerticalAlignment.bottom`**: The view's bottom edge will be aligned to the bottom most relative view.
-
-:pushpin: **Multiple relative views**: If for example a call to `below(of: [...], aligned:) specify multiple relative views, the view will be layouted below *ALL* these views. The alignment will be applied using all relative view
-
-:pushpin: These methods **set the position of a view's anchor**: topLeft, topCenter, topRight, centerLeft, .... For example `below(of ..., aligned: .right)` set the view's topRight anchor, `right(of ..., aligned: .center) set the view's centerLeft anchor, ...
-
-:pushpin: These methods **set the position of a view's edge**: top, left, bottom or right. For example `below(of ...)` set the view's top edge, `right(of ...) set the view's left edge, ...
-
-
-###### Usage examples:
-```swift
-	view.pin.above(of: view2, aligned: .left)
-	view.pin.below(of: [view2, view3, view4], aligned: .left)
-	view.pin.after(of: view2, aligned: .top).before(of: view3, aligned: .bottom)
-```
-
-###### Example:
-The following example layout the view B below the view A aligned on its center.
-
-<img src="docs/pinlayout-relative-with-alignment.png" width="600"/>
-
-
-```swift
-	viewB.pin.below(of: viewA, aligned: .center)
-```
-This is an equivalent solution using anchors:
-
-```swift
-	viewB.pin.topCenter(to: viewA.anchor.bottomCenter)
-```
-
-###### Example:
-The following example layout the view A **below the UIImageView and the UILabel**.
-View A should be left aligned to the UIImageView and right aligned to the UILabel, with a top margin of 10 pixels.
-
-<img src="docs/pinlayout-relative-multi.png" width="600"/>
-
-
-```swift
-	a.pin.below(of: [imageView, label], aligned: .left).right(to: label.edge.right).marginTop(10)
-```
-This is an equivalent solutions using other methods:
-
-```swift
-   let maxY = max(imageView.frame.maxY, label.frame.maxY)  // Not so nice
-   a.pin.top(maxY).left(to: imageView.edge.left).right(to: label.edge.right).marginTop(10)
-```
-
-<br/>
-
-
-### Positioning using only visible relative Views 
-
-All PinLayout's relative methods can accept an array of Views (ex: `below(of: [UIView])`). Using these methods its possible to filter the list of relative Views before the list is used by PinLayout.
-
-PinLayout has a filter method called `visible` that can be used to layout a view related to only visible views. This can be really useful when some views may be visible or hidden depending on the situation.
-
-###### Example:
-The following example contains a UISwitch. Below a UITextField that is visible only when the UISwitch is set to ON. And then follow another UITextField. This example use the `visible(views: [UIView]) -> [UIView]` filter method that returns only views with `UIView.isHidden` set to false or `UIView.alpha` greater than 0.
-
-<img src="docs/pinlayout-relative-visible.png" width="600"/>
-
-
-
-```swift
-   formTitleLabel.pin.topCenter().marginTop(margin)
-   nameField.pin.below(of: formTitleLabel).horizontally().height(40).margin(margin)
-        
-   ageSwitch.pin.below(of: nameField).horizontally().height(40).margin(margin)
-   ageField.pin.below(of: ageSwitch).horizontally().height(40).margin(margin)
-       
-   // Layout the Address UITextField below the last visible view, either ageSwitch or ageField.
-   addressField.pin.below(of: visibles([ageSwitch, ageField])).horizontally().height(40).margin(margin)
-``` 
-
-Note that this example is extracted from the **Form** example, see [Examples App](#examples_app)
 
 <br/>
 
@@ -1519,7 +1568,7 @@ There is an Example app that expose some usage example on PinLayout, including:
 * Example using [`wrapContent()`](#wrapContent)
 * Example showing right-to-left (RTL) language support. Similar to the Intro example.
 * Example showing a simple form example
-* Example showing relative positioning.
+* Example showing Relative Edges layout.
 * Example using Objective-C
 * ...
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,17 @@ In RTL direction position the vertical center (center.y) and the right edge.
 In LTR direction position the vertical center (center.y) and the right edge.
 In RTL direction position the vertical center (center.y) and the left edge.
 
+
+###### Usage Examples:
+
+```swift
+   // Position a view at the top left corner with a top and left margin of 10 pixels
+   view.pin.topLeft(10)
+
+   // Position the 4 edges with a margin of 10 pixels.
+   view.pin.topLeft(10).bottomCenter(10)
+```
+
 <br/>
 
 <a name="relative_edges_layout"></a>

--- a/Sources/PinLayout.swift
+++ b/Sources/PinLayout.swift
@@ -106,11 +106,11 @@ public class PinLayout<View: Layoutable> {
 
     /// Position the view's top edge.
     ///
-    /// - Parameter margin: (Optional, default value is 0). Specifies a distance from the superview's
+    /// - Parameter offset: (Optional, default value is 0). Specifies a distance from the superview's
     ///                     top edge in pixels.
     @discardableResult
-    public func top(_ margin: CGFloat = 0) -> PinLayout {
-        return top(margin, { return "top(\(margin))" })
+    public func top(_ offset: CGFloat = 0) -> PinLayout {
+        return top(offset, { return "top(\(offset.optionnalDescription))" })
     }
 
     /// Position the top edge.
@@ -138,20 +138,20 @@ public class PinLayout<View: Layoutable> {
 
     /// Position the left edge.
     ///
-    /// - Parameter margin: (Optional, default value is 0). Specifies a distance from the superview's
+    /// - Parameter offset: (Optional, default value is 0). Specifies a distance from the superview's
     ///                     left edge in pixels
     @discardableResult
-    public func left(_ margin: CGFloat = 0) -> PinLayout {
-        return left(margin, { return "left(\(margin.optionnalDescription))" })
+    public func left(_ offset: CGFloat = 0) -> PinLayout {
+        return left(offset, { return "left(\(offset.optionnalDescription))" })
     }
 
     /// Position the left edge.
     ///
-    /// - Parameter percent: specifies the left edge distance from the superview's left edge in
-    ///                      percentage of its superview's width.
+    /// - Parameter offset: specifies the left edge distance from the superview's left edge in
+    ///                     percentage of its superview's width.
     @discardableResult
-    public func left(_ percent: Percent) -> PinLayout {
-        return left(percent, { return "left(\(percent.description))" })
+    public func left(_ offset: Percent) -> PinLayout {
+        return left(offset, { return "left(\(offset.description))" })
     }
 
     /// Position the left edge.
@@ -167,24 +167,24 @@ public class PinLayout<View: Layoutable> {
     /// Position the left edge In LTR direction.
     /// Position the right edge In RTL direction.
     ///
-    /// - Parameter margin: (Optional, default value is 0) In LTR direction the value specifies the left
+    /// - Parameter offset: (Optional, default value is 0) In LTR direction the value specifies the left
     ///                     edge distance from the superview's left edge in pixels. In RTL direction the
     ///                     value specifies the right edge distance from the superview's right edge in pixels.
     @discardableResult
-    public func start(_ margin: CGFloat = 0) -> PinLayout {
-        func context() -> String { return "start(\(margin.optionnalDescription))" }
-        return isLTR() ? left(margin, context) : right(margin, context)
+    public func start(_ offset: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "start(\(offset.optionnalDescription))" }
+        return isLTR() ? left(offset, context) : right(offset, context)
     }
 
     /// In LTR direction, position the left edge.
     /// In RTL direction, position the right edge.
     ///
-    /// - Parameter margin: (Optional, default value is 0) Specifies a distance from the superview's
+    /// - Parameter offset: (Optional, default value is 0) Specifies a distance from the superview's
     ///                     corresponding edge in percentage of its superview's width.
     @discardableResult
-    public func start(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "start(\(percent.description))" }
-        return isLTR() ? left(percent, context) : right(percent, context)
+    public func start(_ offset: Percent) -> PinLayout {
+        func context() -> String { return "start(\(offset.description))" }
+        return isLTR() ? left(offset, context) : right(offset, context)
     }
 
     @discardableResult
@@ -194,13 +194,13 @@ public class PinLayout<View: Layoutable> {
     }
     
     @discardableResult
-    public func bottom(_ margin: CGFloat = 0) -> PinLayout {
-        return bottom(margin, { return "bottom(\(margin.optionnalDescription))" })
+    public func bottom(_ offset: CGFloat = 0) -> PinLayout {
+        return bottom(offset, { return "bottom(\(offset.optionnalDescription))" })
     }
 
     @discardableResult
-    public func bottom(_ percent: Percent) -> PinLayout {
-        return bottom(percent, { return "bottom(\(percent.description))" })
+    public func bottom(_ offset: Percent) -> PinLayout {
+        return bottom(offset, { return "bottom(\(offset.description))" })
     }
 
     @discardableResult
@@ -209,13 +209,13 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func right(_ margin: CGFloat = 0) -> PinLayout {
-        return right(margin, { return "right(\(margin.optionnalDescription))" })
+    public func right(_ offset: CGFloat = 0) -> PinLayout {
+        return right(offset, { return "right(\(offset.optionnalDescription))" })
     }
 
     @discardableResult
-    public func right(_ percent: Percent) -> PinLayout {
-        return right(percent, { return "right(\(percent.description))" })
+    public func right(_ offset: Percent) -> PinLayout {
+        return right(offset, { return "right(\(offset.description))" })
     }
 
     @discardableResult
@@ -230,9 +230,9 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func end(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "end(\(percent.description))" }
-        return isLTR() ? right(percent, context) : left(percent, context)
+    public func end(_ offset: Percent) -> PinLayout {
+        func context() -> String { return "end(\(offset.description))" }
+        return isLTR() ? right(offset, context) : left(offset, context)
     }
 
     @discardableResult
@@ -250,10 +250,10 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func hCenter(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "hCenter(\(percent.description))" }
+    public func hCenter(_ offset: Percent) -> PinLayout {
+        func context() -> String { return "hCenter(\(offset.description))" }
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setHorizontalCenter((layoutSuperviewRect.width / 2) + percent.of(layoutSuperviewRect.width), context)
+        setHorizontalCenter((layoutSuperviewRect.width / 2) + offset.of(layoutSuperviewRect.width), context)
         return self
     }
 
@@ -266,10 +266,10 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func vCenter(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "vCenter(\(percent.description))" }
+    public func vCenter(_ offset: Percent) -> PinLayout {
+        func context() -> String { return "vCenter(\(offset.description))" }
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setVerticalCenter((layoutSuperviewRect.height / 2) + percent.of(layoutSuperviewRect.height), context)
+        setVerticalCenter((layoutSuperviewRect.height / 2) + offset.of(layoutSuperviewRect.height), context)
         return self
     }
 

--- a/Sources/PinLayout.swift
+++ b/Sources/PinLayout.swift
@@ -104,17 +104,24 @@ public class PinLayout<View: Layoutable> {
     // top, left, bottom, right
     //
 
+    /// The value specifies the top edge distance from the superview's top edge in pixels.
+    ///  `top()` is similar to calling `top(0)`, it position the view top edge directly on
+    ///  its superview top edge. `top(:UIEdgeInsets)` use the
+    /// `UIEdgeInsets.top` property, is particularly useful with `UIView.pin.safeArea` or
+    /// `UIView.safeAreaInsets`.
+    ///
+    /// - Parameter margin: (optionnal) Specify a margin. Default value is 0.
+    /// - Returns: PinLayout chaining interface
     @discardableResult
-    public func top() -> PinLayout {
-        top({ return "top()" })
-        return self
+    public func top(_ margin: CGFloat = 0) -> PinLayout {
+        return top(margin, { return "top(\(margin))" })
     }
 
-    @discardableResult
-    public func top(_ value: CGFloat) -> PinLayout {
-        return top(value, { return "top(\(value))" })
-    }
-
+    /// The value specifies the top edge distance from the superview's top edge in
+    /// percentage of its superview's height.
+    ///
+    /// - Parameter percent: Specify a margin using a percentage of the view's height.
+    /// - Returns: PinLayout chaining interface
     @discardableResult
     public func top(_ percent: Percent) -> PinLayout {
         func context() -> String { return "top(\(percent.description))" }
@@ -123,43 +130,62 @@ public class PinLayout<View: Layoutable> {
         return self
     }
 
+    /// The value specifies the top edge distance from the superview's top edge in pixels using
+    /// the `UIEdgeInsets.top` property. It is particularly useful with `UIView.pin.safeArea` or
+    /// `UIView.safeAreaInsets`.
     @discardableResult
     public func top(_ insets: PEdgeInsets) -> PinLayout {
         return top(insets.top, { return "top(\(insetsDescription(insets))" })
     }
 
+    /// The value specifies the left edge distance from the superview's left edge in pixels.
+    /// `left()` is similar to calling `left(0)`, it position the view left edge directly on
+    ///  its superview left edge.
+    ///
+    /// - Parameter margin: (optionnal) Specify a margin. Default value is 0.
+    /// - Returns: PinLayout chaining interface
     @discardableResult
-    public func left() -> PinLayout {
-        return left({ return "left()" })
+    public func left(_ margin: CGFloat = 0) -> PinLayout {
+        return left(margin, { return "left(\(margin.optionnalDescription))" })
     }
 
-    @discardableResult
-    public func left(_ value: CGFloat) -> PinLayout {
-        return left(value, { return "left(\(value))" })
-    }
-
+    /// The value specifies the left edge distance from the superview's left edge in
+    /// percentage of its superview's width.
+    ///
+    /// - Parameter percent: Specify a margin using a percentage of the view's width.
+    /// - Returns: PinLayout chaining interface
     @discardableResult
     public func left(_ percent: Percent) -> PinLayout {
         return left(percent, { return "left(\(percent.description))" })
     }
 
+    /// The value specifies the left edge distance from the superview's left edge in pixels using
+    /// the `UIEdgeInsets.left` property. It is particularly useful with `UIView.pin.safeArea` or
+    /// `UIView.safeAreaInsets`.
     @discardableResult
     public func left(_ insets: PEdgeInsets) -> PinLayout {
         return left(insets.left, { return "left(\(insetsDescription(insets))" })
     }
 
+
+    /// In LTR direction the value specifies the left edge distance from the superview's left edge in pixels
+    /// In RTL direction the value specifies the right edge distance from the superview's right edge in pixels
+    ///
+    /// - Parameter margin: (optionnal) Specify a margin. Default value is 0.
+    /// - Returns: PinLayout chaining interface
     @discardableResult
-    public func start() -> PinLayout {
-        func context() -> String { return "start()" }
-        return isLTR() ? left(context) : right(context)
+    public func start(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "start(\(margin.optionnalDescription))" }
+        return isLTR() ? left(margin, context) : right(margin, context)
     }
 
-    @discardableResult
-    public func start(_ value: CGFloat) -> PinLayout {
-        func context() -> String { return "start(\(value))" }
-        return isLTR() ? left(value, context) : right(value, context)
-    }
-
+    /// In LTR direction the value specifies the left edge distance from the superview's left edge in
+    /// percentage of its superview's width.
+    /// In RTL direction the value specifies the right edge distance from the superview's right edge in
+    /// percentage of its superview's width.
+    ///
+    /// - Parameter margin: (optionnal) Specify a margin. Default value is 0.
+    /// - Returns: PinLayout chaining interface
     @discardableResult
     public func start(_ percent: Percent) -> PinLayout {
         func context() -> String { return "start(\(percent.description))" }
@@ -173,13 +199,8 @@ public class PinLayout<View: Layoutable> {
     }
     
     @discardableResult
-    public func bottom() -> PinLayout {
-        return bottom({ return "bottom()" })
-    }
-
-    @discardableResult
-    public func bottom(_ value: CGFloat) -> PinLayout {
-        return bottom(value, { return "bottom(\(value))" })
+    public func bottom(_ margin: CGFloat = 0) -> PinLayout {
+        return bottom(margin, { return "bottom(\(margin.optionnalDescription))" })
     }
 
     @discardableResult
@@ -193,13 +214,8 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func right() -> PinLayout {
-        return right({ return "right()" })
-    }
-
-    @discardableResult
-    public func right(_ value: CGFloat) -> PinLayout {
-        return right(value, { return "right(\(value))" })
+    public func right(_ margin: CGFloat = 0) -> PinLayout {
+        return right(margin, { return "right(\(margin.optionnalDescription))" })
     }
 
     @discardableResult
@@ -213,15 +229,9 @@ public class PinLayout<View: Layoutable> {
     }
     
     @discardableResult
-    public func end() -> PinLayout {
-        func context() -> String { return "end()" }
-        return isLTR() ? right(context) : left(context)
-    }
-
-    @discardableResult
-    public func end(_ value: CGFloat) -> PinLayout {
-        func context() -> String { return "end(\(value))" }
-        return isLTR() ? right(value, context) : left(value, context)
+    public func end(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "end(\(margin.optionnalDescription))" }
+        return isLTR() ? right(margin, context) : left(margin, context)
     }
 
     @discardableResult
@@ -237,18 +247,10 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func hCenter() -> PinLayout {
-        func context() -> String { return "hCenter()" }
+    public func hCenter(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "hCenter(\(margin.optionnalDescription))" }
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setHorizontalCenter(layoutSuperviewRect.width / 2, context)
-        return self
-    }
-
-    @discardableResult
-    public func hCenter(_ value: CGFloat) -> PinLayout {
-        func context() -> String { return "hCenter(\(value))" }
-        guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setHorizontalCenter((layoutSuperviewRect.width / 2) + value, context)
+        setHorizontalCenter((layoutSuperviewRect.width / 2) + margin, context)
         return self
     }
 
@@ -261,18 +263,10 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func vCenter() -> PinLayout {
-        func context() -> String { return "vCenter()" }
+    public func vCenter(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "vCenter(\(margin.optionnalDescription))" }
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setVerticalCenter(layoutSuperviewRect.height / 2, context)
-        return self
-    }
-
-    @discardableResult
-    public func vCenter(_ value: CGFloat) -> PinLayout {
-        func context() -> String { return "vCenter(\(value))" }
-        guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setVerticalCenter((layoutSuperviewRect.height / 2) + value, context)
+        setVerticalCenter((layoutSuperviewRect.height / 2) + margin, context)
         return self
     }
 
@@ -291,26 +285,27 @@ public class PinLayout<View: Layoutable> {
 
      Similar to calling `view.top().bottom().left().right()`
      */
-    @discardableResult
-    public func all() -> PinLayout {
-        top({ "all() top coordinate" })
-        bottom({ "all() bottom coordinate" })
-        right({ "all() right coordinate" })
-        left({ "all() left coordinate" })
-        return self
-    }
+//    @discardableResult
+//    public func all() -> PinLayout {
+//        top({ "all() top coordinate" })
+//        bottom({ "all() bottom coordinate" })
+//        right({ "all() right coordinate" })
+//        left({ "all() left coordinate" })
+//        return self
+//    }
 
     /**
      Pin all edges on its superview's corresponding edges (top, bottom, left, right).
+     The optionnal value specifies edges distance from the superview's corresponding edge in pixels.
 
      Similar to calling `view.top().bottom().left().right()`
      */
     @discardableResult
-    public func all(_ value: CGFloat) -> PinLayout {
-        top(value,  { "all(\(value)) top coordinate" })
-        bottom(value,  { "all(\(value)) bottom coordinate" })
-        left(value,  { "all(\(value)) left coordinate" })
-        right(value,  { "all(\(value)) right coordinate" })
+    public func all(_ margin: CGFloat = 0) -> PinLayout {
+        top(margin,  { "all(\(margin.optionnalDescription)) top coordinate" })
+        bottom(margin,  { "all(\(margin.optionnalDescription)) bottom coordinate" })
+        left(margin,  { "all(\(margin.optionnalDescription)) left coordinate" })
+        right(margin,  { "all(\(margin.optionnalDescription)) right coordinate" })
         return self
     }
 
@@ -333,12 +328,12 @@ public class PinLayout<View: Layoutable> {
 
      Similar to calling `view.left().right()`.
      */
-    @discardableResult
-    public func horizontally() -> PinLayout {
-        right({ "horizontally() right coordinate" })
-        left({ "horizontally() left coordinate" })
-        return self
-    }
+//    @discardableResult
+//    public func horizontally() -> PinLayout {
+//        right({ "horizontally() right coordinate" })
+//        left({ "horizontally() left coordinate" })
+//        return self
+//    }
 
     /**
      Pin the left and right edges on its superview's corresponding edges.
@@ -346,9 +341,9 @@ public class PinLayout<View: Layoutable> {
      Similar to calling `view.left().right()`.
      */
     @discardableResult
-    public func horizontally(_ value: CGFloat) -> PinLayout {
-        left(value, { return "horizontally(\(value)) left coordinate" })
-        right(value, { return "horizontally(\(value)) right coordinate" })
+    public func horizontally(_ margin: CGFloat = 0) -> PinLayout {
+        left(margin, { return "horizontally(\(margin.optionnalDescription)) left coordinate" })
+        right(margin, { return "horizontally(\(margin.optionnalDescription)) right coordinate" })
         return self
     }
 
@@ -381,12 +376,12 @@ public class PinLayout<View: Layoutable> {
 
      Similar to calling `view.top().bottom()`.
      */
-    @discardableResult
-    public func vertically() -> PinLayout {
-        top({ "vertically() top coordinate" })
-        bottom({ "vertically() bottom coordinate" })
-        return self
-    }
+//    @discardableResult
+//    public func vertically() -> PinLayout {
+//        top({ "vertically() top coordinate" })
+//        bottom({ "vertically() bottom coordinate" })
+//        return self
+//    }
 
     /**
      Pin the **top and bottom edges** on its superview's corresponding edges.
@@ -394,9 +389,9 @@ public class PinLayout<View: Layoutable> {
      Similar to calling `view.top().bottom()`.
      */
     @discardableResult
-    public func vertically(_ value: CGFloat) -> PinLayout {
-        top(value, { return "vertically(\(value)) top coordinate" })
-        bottom(value, { return "vertically(\(value)) bottom coordinate" })
+    public func vertically(_ margin: CGFloat = 0) -> PinLayout {
+        top(margin, { return "vertically(\(margin.optionnalDescription)) top coordinate" })
+        bottom(margin, { return "vertically(\(margin.optionnalDescription)) bottom coordinate" })
         return self
     }
 
@@ -520,15 +515,15 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func topLeft() -> PinLayout {
-        return topLeft({ return "topLeft()" })
-    }
-    
-    fileprivate func topLeft(_ context: Context) -> PinLayout {
-        setTopLeft(CGPoint(x: 0, y: 0), { return "topLeft()" })
-        return self
+    public func topLeft(_ margin: CGFloat = 0) -> PinLayout {
+        return topLeft(margin, context: { return "topLeft(\(margin.optionnalDescription)" })
     }
 
+    fileprivate func topLeft(_ margin: CGFloat, context: Context) -> PinLayout {
+        setTopLeft(CGPoint(x: margin, y: margin), context)
+        return self
+    }
+    
     @discardableResult
     public func topStart(to anchor: Anchor) -> PinLayout {
         func context() -> String { return relativeAnchorContext(method: "topStart", anchor: anchor) }
@@ -540,9 +535,9 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func topStart() -> PinLayout {
-        func context() -> String { return "topStart()" }
-        return isLTR() ? topLeft(context) : topRight(context)
+    public func topStart(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "topStart(\(margin.optionnalDescription))" }
+        return isLTR() ? topLeft(margin, context: context) : topRight(margin, context: context)
     }
 
     @discardableResult
@@ -555,10 +550,10 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func topCenter() -> PinLayout {
-        func context() -> String { return "topCenter()" }
+    public func topCenter(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "topCenter(\(margin.optionnalDescription))" }
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setTopCenter(CGPoint(x: layoutSuperviewRect.width / 2, y: 0), context)
+        setTopCenter(CGPoint(x: (layoutSuperviewRect.width / 2) + margin, y: margin), context)
         return self
     }
 
@@ -572,13 +567,13 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func topRight() -> PinLayout {
-        return topRight({ return "topRight()" })
+    public func topRight(_ margin: CGFloat = 0) -> PinLayout {
+        return topRight(margin, context: { return "topRight(\(margin.optionnalDescription))" })
     }
     
-    fileprivate func topRight(_ context: Context) -> PinLayout {
+    fileprivate func topRight(_ margin: CGFloat, context: Context) -> PinLayout {
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setTopRight(CGPoint(x: layoutSuperviewRect.width, y: 0), context)
+        setTopRight(CGPoint(x: layoutSuperviewRect.width - margin, y: margin), context)
         return self
     }
 
@@ -593,9 +588,9 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func topEnd() -> PinLayout {
-        func context() -> String { return "topEnd()" }
-        return isLTR() ? topRight(context) : topLeft(context)
+    public func topEnd(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "topEnd(\(margin.optionnalDescription))" }
+        return isLTR() ? topRight(margin, context: context) : topLeft(margin, context: context)
     }
 
     @discardableResult
@@ -608,13 +603,13 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func centerLeft() -> PinLayout {
-        return centerLeft({ return "centerLeft()" })
+    public func centerLeft(_ margin: CGFloat = 0) -> PinLayout {
+        return centerLeft(margin, context: { return "centerLeft(\(margin.optionnalDescription))" })
     }
     
-    fileprivate func centerLeft(_ context: Context) -> PinLayout {
+    fileprivate func centerLeft(_ margin: CGFloat, context: Context) -> PinLayout {
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setCenterLeft(CGPoint(x: 0, y: layoutSuperviewRect.height / 2), context)
+        setCenterLeft(CGPoint(x: margin, y: (layoutSuperviewRect.height / 2) + margin), context)
         return self
     }
 
@@ -629,9 +624,9 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func centerStart() -> PinLayout {
-        func context() -> String { return "centerStart()" }
-        return isLTR() ? centerLeft(context) : centerRight(context)
+    public func centerStart(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "centerStart(\(margin.optionnalDescription))" }
+        return isLTR() ? centerLeft(margin, context: context) : centerRight(margin, context: context)
     }
 
     @discardableResult
@@ -644,10 +639,10 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func center() -> PinLayout {
-        func context() -> String { return "center()" }
+    public func center(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "center(\(margin.optionnalDescription))" }
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setCenter(CGPoint(x: layoutSuperviewRect.width / 2, y: layoutSuperviewRect.height / 2), context)
+        setCenter(CGPoint(x: (layoutSuperviewRect.width / 2) + margin, y: (layoutSuperviewRect.height / 2) + margin), context)
         return self
     }
 
@@ -661,13 +656,13 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func centerRight() -> PinLayout {
-        return centerRight({ return "centerRight()" })
+    public func centerRight(_ margin: CGFloat = 0) -> PinLayout {
+        return centerRight(margin, context: { return "centerRight(\(margin.optionnalDescription))" })
     }
 
-    fileprivate func centerRight(_ context: Context) -> PinLayout {
+    fileprivate func centerRight(_ margin: CGFloat, context: Context) -> PinLayout {
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setCenterRight(CGPoint(x: layoutSuperviewRect.width, y: layoutSuperviewRect.height / 2), context)
+        setCenterRight(CGPoint(x: layoutSuperviewRect.width - margin, y: (layoutSuperviewRect.height / 2) + margin), context)
         return self
     }
 
@@ -682,9 +677,9 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func centerEnd() -> PinLayout {
-        func context() -> String { return "centerEnd()" }
-        return isLTR() ? centerRight(context) : centerLeft(context)
+    public func centerEnd(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "centerEnd(\(margin.optionnalDescription))" }
+        return isLTR() ? centerRight(margin, context: context) : centerLeft(margin, context: context)
     }
 
     @discardableResult
@@ -697,13 +692,13 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func bottomLeft() -> PinLayout {
-        return bottomLeft({ return "bottomLeft()" })
+    public func bottomLeft(_ margin: CGFloat = 0) -> PinLayout {
+        return bottomLeft(margin, context: { return "bottomLeft(\(margin.optionnalDescription))" })
     }
 
-    fileprivate func bottomLeft(_ context: Context) -> PinLayout {
+    fileprivate func bottomLeft(_ margin: CGFloat, context: Context) -> PinLayout {
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setBottomLeft(CGPoint(x: 0, y: layoutSuperviewRect.height), context)
+        setBottomLeft(CGPoint(x: margin, y: layoutSuperviewRect.height - margin), context)
         return self
     }
 
@@ -718,9 +713,9 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func bottomStart() -> PinLayout {
-        func context() -> String { return "bottomStart()" }
-        return isLTR() ? bottomLeft(context) : bottomRight(context)
+    public func bottomStart(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "bottomStart(\(margin.optionnalDescription)" }
+        return isLTR() ? bottomLeft(margin, context: context) : bottomRight(margin, context: context)
     }
 
     @discardableResult
@@ -733,10 +728,10 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func bottomCenter() -> PinLayout {
-        func context() -> String { return "bottomCenter()" }
+    public func bottomCenter(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "bottomCenter(\(margin.optionnalDescription))" }
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setBottomCenter(CGPoint(x: layoutSuperviewRect.width / 2, y: layoutSuperviewRect.height), context)
+        setBottomCenter(CGPoint(x: (layoutSuperviewRect.width / 2) + margin, y: layoutSuperviewRect.height - margin), context)
         return self
     }
 
@@ -750,13 +745,13 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func bottomRight() -> PinLayout {
-        return bottomRight({ return "bottomRight()" })
+    public func bottomRight(_ margin: CGFloat = 0) -> PinLayout {
+        return bottomRight(margin, context: { return "bottomRight(\(margin.optionnalDescription))" })
     }
 
-    fileprivate func bottomRight(_ context: Context) -> PinLayout {
+    fileprivate func bottomRight(_ margin: CGFloat, context: Context) -> PinLayout {
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setBottomRight(CGPoint(x: layoutSuperviewRect.width, y: layoutSuperviewRect.height), context)
+        setBottomRight(CGPoint(x: layoutSuperviewRect.width - margin, y: layoutSuperviewRect.height - margin), context)
         return self
     }
 
@@ -771,9 +766,9 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func bottomEnd() -> PinLayout {
-        func context() -> String { return "bottomEnd()" }
-        return isLTR() ? bottomRight(context) : bottomLeft(context)
+    public func bottomEnd(_ margin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "bottomEnd(\(margin.optionnalDescription))" }
+        return isLTR() ? bottomRight(margin, context: context) : bottomLeft(margin, context: context)
     }
 
     //
@@ -892,8 +887,8 @@ public class PinLayout<View: Layoutable> {
      Set the top margin.
      */
     @discardableResult
-    public func marginTop(_ value: CGFloat) -> PinLayout {
-        marginTop = value
+    public func marginTop(_ margin: CGFloat) -> PinLayout {
+        marginTop = margin
         return self
     }
 
@@ -916,8 +911,8 @@ public class PinLayout<View: Layoutable> {
      Set the left margin.
      */
     @discardableResult
-    public func marginLeft(_ value: CGFloat) -> PinLayout {
-        marginLeft = value
+    public func marginLeft(_ margin: CGFloat) -> PinLayout {
+        marginLeft = margin
         return self
     }
 
@@ -940,8 +935,8 @@ public class PinLayout<View: Layoutable> {
      Set the bottom margin.
      */
     @discardableResult
-    public func marginBottom(_ value: CGFloat) -> PinLayout {
-        marginBottom = value
+    public func marginBottom(_ margin: CGFloat) -> PinLayout {
+        marginBottom = margin
         return self
     }
 
@@ -964,8 +959,8 @@ public class PinLayout<View: Layoutable> {
      Set the right margin.
      */
     @discardableResult
-    public func marginRight(_ value: CGFloat) -> PinLayout {
-        marginRight = value
+    public func marginRight(_ margin: CGFloat) -> PinLayout {
+        marginRight = margin
         return self
     }
 
@@ -994,8 +989,8 @@ public class PinLayout<View: Layoutable> {
      * In RTL direction, start margin specify the **right** margin.
      */
     @discardableResult
-    public func marginStart(_ value: CGFloat) -> PinLayout {
-        return isLTR() ? marginLeft(value) : marginRight(value)
+    public func marginStart(_ margin: CGFloat) -> PinLayout {
+        return isLTR() ? marginLeft(margin) : marginRight(margin)
     }
 
     /**
@@ -1019,8 +1014,8 @@ public class PinLayout<View: Layoutable> {
      * In RTL direction, end margin specify the **left** margin.
      */
     @discardableResult
-    public func marginEnd(_ value: CGFloat) -> PinLayout {
-        return isLTR() ? marginRight(value) : marginLeft(value)
+    public func marginEnd(_ margin: CGFloat) -> PinLayout {
+        return isLTR() ? marginRight(margin) : marginLeft(margin)
     }
 
     /**
@@ -1040,9 +1035,9 @@ public class PinLayout<View: Layoutable> {
      Set the left, right, start and end margins to the specified value.
      */
     @discardableResult
-    public func marginHorizontal(_ value: CGFloat) -> PinLayout {
-        marginLeft = value
-        marginRight = value
+    public func marginHorizontal(_ margin: CGFloat) -> PinLayout {
+        marginLeft = margin
+        marginRight = margin
         return self
     }
 
@@ -1063,9 +1058,9 @@ public class PinLayout<View: Layoutable> {
      Set the top and bottom margins to the specified value.
      */
     @discardableResult
-    public func marginVertical(_ value: CGFloat) -> PinLayout {
-        marginTop = value
-        marginBottom = value
+    public func marginVertical(_ margin: CGFloat) -> PinLayout {
+        marginTop = margin
+        marginBottom = margin
         return self
     }
 
@@ -1117,11 +1112,11 @@ public class PinLayout<View: Layoutable> {
      Set all margins to the specified value.
      */
     @discardableResult
-    public func margin(_ value: CGFloat) -> PinLayout {
-        marginTop = value
-        marginLeft = value
-        marginBottom = value
-        marginRight = value
+    public func margin(_ margin: CGFloat) -> PinLayout {
+        marginTop = margin
+        marginLeft = margin
+        marginBottom = margin
+        marginRight = margin
         return self
     }
 

--- a/Sources/PinLayout.swift
+++ b/Sources/PinLayout.swift
@@ -104,24 +104,19 @@ public class PinLayout<View: Layoutable> {
     // top, left, bottom, right
     //
 
-    /// The value specifies the top edge distance from the superview's top edge in pixels.
-    ///  `top()` is similar to calling `top(0)`, it position the view top edge directly on
-    ///  its superview top edge. `top(:UIEdgeInsets)` use the
-    /// `UIEdgeInsets.top` property, is particularly useful with `UIView.pin.safeArea` or
-    /// `UIView.safeAreaInsets`.
+    /// Position the view's top edge.
     ///
-    /// - Parameter margin: (optionnal) Specify a margin. Default value is 0.
-    /// - Returns: PinLayout chaining interface
+    /// - Parameter margin: (Optional, default value is 0). Specifies a distance from the superview's
+    ///                     top edge in pixels.
     @discardableResult
     public func top(_ margin: CGFloat = 0) -> PinLayout {
         return top(margin, { return "top(\(margin))" })
     }
 
-    /// The value specifies the top edge distance from the superview's top edge in
-    /// percentage of its superview's height.
+    /// Position the top edge.
     ///
-    /// - Parameter percent: Specify a margin using a percentage of the view's height.
-    /// - Returns: PinLayout chaining interface
+    /// - Parameter percent: Specifies the top edge distance from the superview's top edge in
+    ///                      percentage of its superview's height.
     @discardableResult
     public func top(_ percent: Percent) -> PinLayout {
         func context() -> String { return "top(\(percent.description))" }
@@ -130,62 +125,62 @@ public class PinLayout<View: Layoutable> {
         return self
     }
 
-    /// The value specifies the top edge distance from the superview's top edge in pixels using
-    /// the `UIEdgeInsets.top` property. It is particularly useful with `UIView.pin.safeArea` or
-    /// `UIView.safeAreaInsets`.
+    /// Position the top edge.
+    /// The value
+    ///
+    /// - Parameter insets: specifies the top edge distance from the superview's top edge in pixels using
+    ///                     the `UIEdgeInsets.top` property. It is particularly useful with `UIView.pin.safeArea` or
+    ///                     `UIView.safeAreaInsets`.
     @discardableResult
     public func top(_ insets: PEdgeInsets) -> PinLayout {
         return top(insets.top, { return "top(\(insetsDescription(insets))" })
     }
 
-    /// The value specifies the left edge distance from the superview's left edge in pixels.
-    /// `left()` is similar to calling `left(0)`, it position the view left edge directly on
-    ///  its superview left edge.
+    /// Position the left edge.
     ///
-    /// - Parameter margin: (optionnal) Specify a margin. Default value is 0.
-    /// - Returns: PinLayout chaining interface
+    /// - Parameter margin: (Optional, default value is 0). Specifies a distance from the superview's
+    ///                     left edge in pixels
     @discardableResult
     public func left(_ margin: CGFloat = 0) -> PinLayout {
         return left(margin, { return "left(\(margin.optionnalDescription))" })
     }
 
-    /// The value specifies the left edge distance from the superview's left edge in
-    /// percentage of its superview's width.
+    /// Position the left edge.
     ///
-    /// - Parameter percent: Specify a margin using a percentage of the view's width.
-    /// - Returns: PinLayout chaining interface
+    /// - Parameter percent: specifies the left edge distance from the superview's left edge in
+    ///                      percentage of its superview's width.
     @discardableResult
     public func left(_ percent: Percent) -> PinLayout {
         return left(percent, { return "left(\(percent.description))" })
     }
 
-    /// The value specifies the left edge distance from the superview's left edge in pixels using
-    /// the `UIEdgeInsets.left` property. It is particularly useful with `UIView.pin.safeArea` or
-    /// `UIView.safeAreaInsets`.
+    /// Position the left edge.
+    ///
+    /// - Parameter insets: specifies the left edge distance from the superview's left edge in pixels using
+    ///                     the `UIEdgeInsets.left` property. It is particularly useful with `UIView.pin.safeArea` or
+    ///                     `UIView.safeAreaInsets`.
     @discardableResult
     public func left(_ insets: PEdgeInsets) -> PinLayout {
         return left(insets.left, { return "left(\(insetsDescription(insets))" })
     }
 
-
-    /// In LTR direction the value specifies the left edge distance from the superview's left edge in pixels
-    /// In RTL direction the value specifies the right edge distance from the superview's right edge in pixels
+    /// Position the left edge In LTR direction.
+    /// Position the right edge In RTL direction.
     ///
-    /// - Parameter margin: (optionnal) Specify a margin. Default value is 0.
-    /// - Returns: PinLayout chaining interface
+    /// - Parameter margin: (Optional, default value is 0) In LTR direction the value specifies the left
+    ///                     edge distance from the superview's left edge in pixels. In RTL direction the
+    ///                     value specifies the right edge distance from the superview's right edge in pixels.
     @discardableResult
     public func start(_ margin: CGFloat = 0) -> PinLayout {
         func context() -> String { return "start(\(margin.optionnalDescription))" }
         return isLTR() ? left(margin, context) : right(margin, context)
     }
 
-    /// In LTR direction the value specifies the left edge distance from the superview's left edge in
-    /// percentage of its superview's width.
-    /// In RTL direction the value specifies the right edge distance from the superview's right edge in
-    /// percentage of its superview's width.
+    /// In LTR direction, position the left edge.
+    /// In RTL direction, position the right edge.
     ///
-    /// - Parameter margin: (optionnal) Specify a margin. Default value is 0.
-    /// - Returns: PinLayout chaining interface
+    /// - Parameter margin: (Optional, default value is 0) Specifies a distance from the superview's
+    ///                     corresponding edge in percentage of its superview's width.
     @discardableResult
     public func start(_ percent: Percent) -> PinLayout {
         func context() -> String { return "start(\(percent.description))" }
@@ -282,20 +277,6 @@ public class PinLayout<View: Layoutable> {
 
     /**
      Pin all edges on its superview's corresponding edges (top, bottom, left, right).
-
-     Similar to calling `view.top().bottom().left().right()`
-     */
-//    @discardableResult
-//    public func all() -> PinLayout {
-//        top({ "all() top coordinate" })
-//        bottom({ "all() bottom coordinate" })
-//        right({ "all() right coordinate" })
-//        left({ "all() left coordinate" })
-//        return self
-//    }
-
-    /**
-     Pin all edges on its superview's corresponding edges (top, bottom, left, right).
      The optionnal value specifies edges distance from the superview's corresponding edge in pixels.
 
      Similar to calling `view.top().bottom().left().right()`
@@ -322,18 +303,6 @@ public class PinLayout<View: Layoutable> {
         right(insets.right,  { "all(\(insets)) right coordinate" })
         return self
     }
-
-    /**
-     Pin the left and right edges on its superview's corresponding edges.
-
-     Similar to calling `view.left().right()`.
-     */
-//    @discardableResult
-//    public func horizontally() -> PinLayout {
-//        right({ "horizontally() right coordinate" })
-//        left({ "horizontally() left coordinate" })
-//        return self
-//    }
 
     /**
      Pin the left and right edges on its superview's corresponding edges.
@@ -370,18 +339,6 @@ public class PinLayout<View: Layoutable> {
         right(insets.right, { return "horizontally(\(insets)) right coordinate" })
         return self
     }
-
-    /**
-     Pin the **top and bottom edges** on its superview's corresponding edges.
-
-     Similar to calling `view.top().bottom()`.
-     */
-//    @discardableResult
-//    public func vertically() -> PinLayout {
-//        top({ "vertically() top coordinate" })
-//        bottom({ "vertically() bottom coordinate" })
-//        return self
-//    }
 
     /**
      Pin the **top and bottom edges** on its superview's corresponding edges.
@@ -514,16 +471,15 @@ public class PinLayout<View: Layoutable> {
         return self
     }
 
+    /// Position the top and left edges.
+    ///
+    /// - Parameter margin: (Optional, default value is 0). Specifies a distance from their superview's
+    //                      corresponding edges in pixels
     @discardableResult
     public func topLeft(_ margin: CGFloat = 0) -> PinLayout {
         return topLeft(margin, context: { return "topLeft(\(margin.optionnalDescription)" })
     }
 
-    fileprivate func topLeft(_ margin: CGFloat, context: Context) -> PinLayout {
-        setTopLeft(CGPoint(x: margin, y: margin), context)
-        return self
-    }
-    
     @discardableResult
     public func topStart(to anchor: Anchor) -> PinLayout {
         func context() -> String { return relativeAnchorContext(method: "topStart", anchor: anchor) }
@@ -534,10 +490,20 @@ public class PinLayout<View: Layoutable> {
         return self
     }
 
+    /// In LTR direction position the top and left edges.
+    /// In RTL direction position the top and right edges.
+    ///
+    /// - Parameter margin: specifies the distance from their superview's
+    ///                     corresponding edges in pixels.
     @discardableResult
     public func topStart(_ margin: CGFloat = 0) -> PinLayout {
         func context() -> String { return "topStart(\(margin.optionnalDescription))" }
         return isLTR() ? topLeft(margin, context: context) : topRight(margin, context: context)
+    }
+
+    fileprivate func topLeft(_ margin: CGFloat, context: Context) -> PinLayout {
+        setTopLeft(CGPoint(x: margin, y: margin), context)
+        return self
     }
 
     @discardableResult
@@ -550,10 +516,10 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func topCenter(_ margin: CGFloat = 0) -> PinLayout {
-        func context() -> String { return "topCenter(\(margin.optionnalDescription))" }
+    public func topCenter(_ topMargin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "topCenter(\(topMargin.optionnalDescription))" }
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setTopCenter(CGPoint(x: (layoutSuperviewRect.width / 2) + margin, y: margin), context)
+        setTopCenter(CGPoint(x: layoutSuperviewRect.width / 2, y: topMargin), context)
         return self
     }
 
@@ -571,12 +537,6 @@ public class PinLayout<View: Layoutable> {
         return topRight(margin, context: { return "topRight(\(margin.optionnalDescription))" })
     }
     
-    fileprivate func topRight(_ margin: CGFloat, context: Context) -> PinLayout {
-        guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setTopRight(CGPoint(x: layoutSuperviewRect.width - margin, y: margin), context)
-        return self
-    }
-
     @discardableResult
     public func topEnd(to anchor: Anchor) -> PinLayout {
         func context() -> String { return relativeAnchorContext(method: "topEnd", anchor: anchor) }
@@ -593,6 +553,12 @@ public class PinLayout<View: Layoutable> {
         return isLTR() ? topRight(margin, context: context) : topLeft(margin, context: context)
     }
 
+    fileprivate func topRight(_ margin: CGFloat, context: Context) -> PinLayout {
+        guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
+        setTopRight(CGPoint(x: layoutSuperviewRect.width - margin, y: margin), context)
+        return self
+    }
+
     @discardableResult
     public func centerLeft(to anchor: Anchor) -> PinLayout {
         func context() -> String { return relativeAnchorContext(method: "centerLeft", anchor: anchor) }
@@ -603,16 +569,10 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func centerLeft(_ margin: CGFloat = 0) -> PinLayout {
-        return centerLeft(margin, context: { return "centerLeft(\(margin.optionnalDescription))" })
+    public func centerLeft(_ leftMargin: CGFloat = 0) -> PinLayout {
+        return centerLeft(leftMargin, context: { return "centerLeft(\(leftMargin.optionnalDescription))" })
     }
     
-    fileprivate func centerLeft(_ margin: CGFloat, context: Context) -> PinLayout {
-        guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setCenterLeft(CGPoint(x: margin, y: (layoutSuperviewRect.height / 2) + margin), context)
-        return self
-    }
-
     @discardableResult
     public func centerStart(to anchor: Anchor) -> PinLayout {
         func context() -> String { return relativeAnchorContext(method: "centerStart", anchor: anchor) }
@@ -624,9 +584,15 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func centerStart(_ margin: CGFloat = 0) -> PinLayout {
-        func context() -> String { return "centerStart(\(margin.optionnalDescription))" }
-        return isLTR() ? centerLeft(margin, context: context) : centerRight(margin, context: context)
+    public func centerStart(_ startMargin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "centerStart(\(startMargin.optionnalDescription))" }
+        return isLTR() ? centerLeft(startMargin, context: context) : centerRight(startMargin, context: context)
+    }
+
+    fileprivate func centerLeft(_ leftMargin: CGFloat, context: Context) -> PinLayout {
+        guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
+        setCenterLeft(CGPoint(x: leftMargin, y: layoutSuperviewRect.height / 2), context)
+        return self
     }
 
     @discardableResult
@@ -656,14 +622,8 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func centerRight(_ margin: CGFloat = 0) -> PinLayout {
-        return centerRight(margin, context: { return "centerRight(\(margin.optionnalDescription))" })
-    }
-
-    fileprivate func centerRight(_ margin: CGFloat, context: Context) -> PinLayout {
-        guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setCenterRight(CGPoint(x: layoutSuperviewRect.width - margin, y: (layoutSuperviewRect.height / 2) + margin), context)
-        return self
+    public func centerRight(_ rightMargin: CGFloat = 0) -> PinLayout {
+        return centerRight(rightMargin, context: { return "centerRight(\(rightMargin.optionnalDescription))" })
     }
 
     @discardableResult
@@ -677,9 +637,15 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func centerEnd(_ margin: CGFloat = 0) -> PinLayout {
-        func context() -> String { return "centerEnd(\(margin.optionnalDescription))" }
-        return isLTR() ? centerRight(margin, context: context) : centerLeft(margin, context: context)
+    public func centerEnd(_ endMargin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "centerEnd(\(endMargin.optionnalDescription))" }
+        return isLTR() ? centerRight(endMargin, context: context) : centerLeft(endMargin, context: context)
+    }
+
+    fileprivate func centerRight(_ rightMargin: CGFloat, context: Context) -> PinLayout {
+        guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
+        setCenterRight(CGPoint(x: layoutSuperviewRect.width - rightMargin, y: layoutSuperviewRect.height / 2), context)
+        return self
     }
 
     @discardableResult
@@ -728,10 +694,10 @@ public class PinLayout<View: Layoutable> {
     }
 
     @discardableResult
-    public func bottomCenter(_ margin: CGFloat = 0) -> PinLayout {
-        func context() -> String { return "bottomCenter(\(margin.optionnalDescription))" }
+    public func bottomCenter(_ bottomMargin: CGFloat = 0) -> PinLayout {
+        func context() -> String { return "bottomCenter(\(bottomMargin.optionnalDescription))" }
         guard let layoutSuperviewRect = layoutSuperviewRect(context) else { return self }
-        setBottomCenter(CGPoint(x: (layoutSuperviewRect.width / 2) + margin, y: layoutSuperviewRect.height - margin), context)
+        setBottomCenter(CGPoint(x: layoutSuperviewRect.width / 2, y: layoutSuperviewRect.height - bottomMargin), context)
         return self
     }
 
@@ -1204,8 +1170,6 @@ public class PinLayout<View: Layoutable> {
     /// This is also true even if the width has been set.
     /// Calling pinEdges() will force PinLayout to pin the four edges and then apply left and/or right margins, and this without
     /// moving the view.
-    ///
-    /// - Returns: PinLayout
     @discardableResult
     public func pinEdges() -> PinLayout {
         shouldPinEdges = true

--- a/Sources/Types+Description.swift
+++ b/Sources/Types+Description.swift
@@ -46,12 +46,16 @@ extension VerticalAlign {
 }
 
 extension CGFloat {
-    public var description: String {
+    var description: String {
         if self.truncatingRemainder(dividingBy: 1) == 0.0 {
             return "\(Int(self))"
         } else {
             return "\(self)"
         }
+    }
+
+    var optionnalDescription: String {
+        return self == 0 ? "" : self.description
     }
 }
 

--- a/Tests/Common/PinEdgesSpec.swift
+++ b/Tests/Common/PinEdgesSpec.swift
@@ -592,11 +592,11 @@ class PinEdgesSpec: QuickSpec {
             }
             it("should warn") {
                 aView.pin.left(10).horizontally(20)
-                expect(Pin.lastWarningText).to(contain(["horizontally(20.0) left coordinate", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["horizontally(20) left coordinate", "won't be applied", "already been set to 10"]))
             }
             it("should warn") {
                 aView.pin.right(10).horizontally(20)
-                expect(Pin.lastWarningText).to(contain(["horizontally(20.0) right coordinate", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["horizontally(20) right coordinate", "won't be applied", "already been set to 10"]))
             }
             it("should warn") {
                 aView.pin.left(10).horizontally(10%)
@@ -658,11 +658,11 @@ class PinEdgesSpec: QuickSpec {
             }
             it("should warn") {
                 aView.pin.top(10).vertically(20)
-                expect(Pin.lastWarningText).to(contain(["vertically(20.0) top coordinate", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["vertically(20) top coordinate", "won't be applied", "already been set to 10"]))
             }
             it("should warn") {
                 aView.pin.bottom(10).vertically(20)
-                expect(Pin.lastWarningText).to(contain(["vertically(20.0) bottom coordinate", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["vertically(20) bottom coordinate", "won't be applied", "already been set to 10"]))
             }
             it("should warn") {
                 aView.pin.top(10).vertically(10%)

--- a/Tests/Common/PinPointCoordinatesSpec.swift
+++ b/Tests/Common/PinPointCoordinatesSpec.swift
@@ -198,7 +198,7 @@ class PinPointCoordinatesSpec: QuickSpec {
 
             it("should position the aView's topCenter corner on its parent's topCenter corner") {
                 aView.pin.topCenter(10)
-                expect(aView.frame).to(equal(CGRect(x: 160.0, y: 10.0, width: 100.0, height: 60.0)))
+                expect(aView.frame).to(equal(CGRect(x: 150.0, y: 10.0, width: 100.0, height: 60.0)))
             }
             
             it("should position the aViewChild's topCenter corner on the specified view's topCenter corner") {
@@ -337,7 +337,7 @@ class PinPointCoordinatesSpec: QuickSpec {
 
             it("should position the aView's centerLeft corner at the specified position") {
                 aView.pin.centerLeft(10)
-                expect(aView.frame).to(equal(CGRect(x: 10.0, y: 180.0, width: 100.0, height: 60.0)))
+                expect(aView.frame).to(equal(CGRect(x: 10.0, y: 170.0, width: 100.0, height: 60.0)))
             }
             
             it("should position the aView's centerLeft corner at the specified position") {
@@ -471,7 +471,7 @@ class PinPointCoordinatesSpec: QuickSpec {
 
             it("should position the aView's centerRight corner at the specified position") {
                 aView.pin.centerRight(10)
-                expect(aView.frame).to(equal(CGRect(x: 290.0, y: 180.0, width: 100.0, height: 60.0)))
+                expect(aView.frame).to(equal(CGRect(x: 290.0, y: 170.0, width: 100.0, height: 60.0)))
             }
 
             it("should position the aView's centerRight corner at the specified position") {
@@ -595,7 +595,7 @@ class PinPointCoordinatesSpec: QuickSpec {
 
             it("should position the aView's bottomCenter corner at the specified position") {
                 aView.pin.bottomCenter(10)
-                expect(aView.frame).to(equal(CGRect(x: 160.0, y: 330.0, width: 100.0, height: 60.0)))
+                expect(aView.frame).to(equal(CGRect(x: 150.0, y: 330.0, width: 100.0, height: 60.0)))
             }
 
             it("should position the aView's bottomCenter corner at the specified position") {

--- a/Tests/Common/PinPointCoordinatesSpec.swift
+++ b/Tests/Common/PinPointCoordinatesSpec.swift
@@ -123,6 +123,11 @@ class PinPointCoordinatesSpec: QuickSpec {
                 aView.pin.topLeft()
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 0.0, width: 100.0, height: 60.0)))
             }
+
+            it("should position the aView's topLeft corner on its parent's topLeft corner") {
+                aView.pin.topLeft(10)
+                expect(aView.frame).to(equal(CGRect(x: 10.0, y: 10.0, width: 100.0, height: 60.0)))
+            }
             
             it("should position the aViewChild's topLeft corner on the specified view's topLeft corner") {
                 aViewChild.pin.topLeft(to: aView.anchor.topLeft)
@@ -189,6 +194,11 @@ class PinPointCoordinatesSpec: QuickSpec {
             it("should position the aView's topCenter corner on its parent's topCenter corner") {
                 aView.pin.topCenter()
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 0.0, width: 100.0, height: 60.0)))
+            }
+
+            it("should position the aView's topCenter corner on its parent's topCenter corner") {
+                aView.pin.topCenter(10)
+                expect(aView.frame).to(equal(CGRect(x: 160.0, y: 10.0, width: 100.0, height: 60.0)))
             }
             
             it("should position the aViewChild's topCenter corner on the specified view's topCenter corner") {
@@ -257,6 +267,11 @@ class PinPointCoordinatesSpec: QuickSpec {
                 aView.pin.topRight()
                 expect(aView.frame).to(equal(CGRect(x: 300.0, y: 0.0, width: 100.0, height: 60.0)))
             }
+
+            it("should position the aView's topRight corner at the specified position") {
+                aView.pin.topRight(10)
+                expect(aView.frame).to(equal(CGRect(x: 290.0, y: 10.0, width: 100.0, height: 60.0)))
+            }
             
             it("should position the aView's topRight corner at the specified position") {
                 aViewChild.pin.topRight(to: aView.anchor.topLeft)
@@ -318,6 +333,11 @@ class PinPointCoordinatesSpec: QuickSpec {
             it("should position the aView's centerLeft corner at the specified position") {
                 aView.pin.centerLeft()
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 170.0, width: 100.0, height: 60.0)))
+            }
+
+            it("should position the aView's centerLeft corner at the specified position") {
+                aView.pin.centerLeft(10)
+                expect(aView.frame).to(equal(CGRect(x: 10.0, y: 180.0, width: 100.0, height: 60.0)))
             }
             
             it("should position the aView's centerLeft corner at the specified position") {
@@ -386,6 +406,11 @@ class PinPointCoordinatesSpec: QuickSpec {
                 aView.pin.center()
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 170.0, width: 100.0, height: 60.0)))
             }
+
+            it("should position the aView's center corner at the specified position") {
+                aView.pin.center(10)
+                expect(aView.frame).to(equal(CGRect(x: 160.0, y: 180.0, width: 100.0, height: 60.0)))
+            }
             
             it("should position the aView's center corner at the specified position") {
                 aViewChild.pin.center(to: aView.anchor.topLeft)
@@ -442,6 +467,11 @@ class PinPointCoordinatesSpec: QuickSpec {
             it("should position the aView's centerRight corner at the specified position") {
                 aView.pin.centerRight()
                 expect(aView.frame).to(equal(CGRect(x: 300.0, y: 170.0, width: 100.0, height: 60.0)))
+            }
+
+            it("should position the aView's centerRight corner at the specified position") {
+                aView.pin.centerRight(10)
+                expect(aView.frame).to(equal(CGRect(x: 290.0, y: 180.0, width: 100.0, height: 60.0)))
             }
 
             it("should position the aView's centerRight corner at the specified position") {
@@ -502,6 +532,11 @@ class PinPointCoordinatesSpec: QuickSpec {
             }
 
             it("should position the aView's bottomLeft corner at the specified position") {
+                aView.pin.bottomLeft(10)
+                expect(aView.frame).to(equal(CGRect(x: 10.0, y: 330.0, width: 100.0, height: 60.0)))
+            }
+
+            it("should position the aView's bottomLeft corner at the specified position") {
                 aViewChild.pin.bottomLeft(to: aView.anchor.topLeft)
                 expect(aViewChild.frame).to(equal(CGRect(x: 0.0, y: -30.0, width: 50.0, height: 30.0)))
                 aViewChild.pin.bottomLeft(to: aView.anchor.topCenter)
@@ -559,6 +594,11 @@ class PinPointCoordinatesSpec: QuickSpec {
             }
 
             it("should position the aView's bottomCenter corner at the specified position") {
+                aView.pin.bottomCenter(10)
+                expect(aView.frame).to(equal(CGRect(x: 160.0, y: 330.0, width: 100.0, height: 60.0)))
+            }
+
+            it("should position the aView's bottomCenter corner at the specified position") {
                 aViewChild.pin.bottomCenter(to: aView.anchor.topLeft)
                 expect(aViewChild.frame).to(equal(CGRect(x: -25.0, y: -30.0, width: 50.0, height: 30.0)))
                 aViewChild.pin.bottomCenter(to: aView.anchor.topCenter)
@@ -613,6 +653,11 @@ class PinPointCoordinatesSpec: QuickSpec {
             it("should position the aView's bottomRight corner at the specified position") {
                 aView.pin.bottomRight()
                 expect(aView.frame).to(equal(CGRect(x: 300.0, y: 340.0, width: 100.0, height: 60.0)))
+            }
+
+            it("should position the aView's bottomRight corner at the specified position") {
+                aView.pin.bottomRight(10)
+                expect(aView.frame).to(equal(CGRect(x: 290.0, y: 330.0, width: 100.0, height: 60.0)))
             }
 
             it("should position the aView's bottomRight corner at the specified position") {


### PR DESCRIPTION
Method that position multiple edges now accept an `offset` parameter that specifies the distance from their superview's corresponding edges in pixels.

* `topLeft(_ offset: CGFloat)`
* `topCenter(_ topOffset: CGFloat)`
* `topRight(_ offset: CGFloat)`

* `centerLeft(_ leftOffset: CGFloat)`
* `center(_ offset: CGFloat)`
* `centerRight(_ rightOffset offset: CGFloat)`

* `bottomLeft(_ offset: CGFloat)`
* `bottomCenter(_ bottomOffset: CGFloat)`
* `bottomRight(_ offset: CGFloat)`

For example, to position a view at the top left corner with a top and left margin of 10 pixels:

```
   view.pin.topLeft(10)
```

Previously, the required line was:
```
  view.pin.topLeft().margin(10)
```


Plus:
* Cleanup the interface by using default value parameters.