### PR TITLE
Deprecated method `fitSize()` has been removed

### DIFF
--- a/Example/PinLayoutSample/UI/Common/BasicView.swift
+++ b/Example/PinLayoutSample/UI/Common/BasicView.swift
@@ -43,7 +43,7 @@ class BasicView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
             
-        label.pin.top().left().right().margin(4).sizeToFit(.width)
+        label.pin.top().horizontally().margin(4).sizeToFit(.width)
     }
     
     var sizeThatFitsExpectedArea: CGFloat = 40 * 40

--- a/Example/PinLayoutSample/UI/Examples/MultiRelativeView/MultiRelativeView.swift
+++ b/Example/PinLayoutSample/UI/Examples/MultiRelativeView/MultiRelativeView.swift
@@ -44,7 +44,7 @@ class MultiRelativeView: UIView {
         
         view1.pin.top(pin.safeArea).left(pin.safeArea).width(20%).height(50%)
         view2.pin.top(pin.safeArea).right(pin.safeArea).width(20%).height(50%)
-        
-        view.pin.right(of: view1, aligned: .top).left(of: view2, aligned: .bottom).marginHorizontal(10)
+
+        view.pin.after(of: view1, aligned: .top).before(of: view2, aligned: .bottom).marginHorizontal(10)
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/RelativeView/RelativeView.swift
+++ b/Example/PinLayoutSample/UI/Examples/RelativeView/RelativeView.swift
@@ -85,16 +85,16 @@ class RelativeView: UIView {
         topCenterView.pin.above(of: centerView, aligned: .center).marginBottom(10)
         topRightView.pin.above(of: centerView, aligned: .right).marginBottom(10)
         
-        rightTopView.pin.right(of: centerView, aligned: .top).marginLeft(10)
-        rightCenterView.pin.right(of: centerView, aligned: .center).marginLeft(10)
-        rightBottomView.pin.right(of: centerView, aligned: .bottom).marginLeft(10)
+        rightTopView.pin.after(of: centerView, aligned: .top).marginLeft(10)
+        rightCenterView.pin.after(of: centerView, aligned: .center).marginLeft(10)
+        rightBottomView.pin.after(of: centerView, aligned: .bottom).marginLeft(10)
         
         bottomLeftView.pin.below(of: centerView, aligned: .left).marginTop(10)
         bottomCenterView.pin.below(of: centerView, aligned: .center).marginTop(10)
         bottomRightView.pin.below(of: centerView, aligned: .right).marginTop(10)
 
-        leftTopView.pin.left(of: centerView, aligned: .top).marginRight(10)
-        leftCenterView.pin.left(of: centerView, aligned: .center).marginRight(10)
-        leftBottomView.pin.left(of: centerView, aligned: .bottom).marginRight(10)
+        leftTopView.pin.before(of: centerView, aligned: .top).marginRight(10)
+        leftCenterView.pin.before(of: centerView, aligned: .center).marginRight(10)
+        leftBottomView.pin.before(of: centerView, aligned: .bottom).marginRight(10)
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/TableViewExample/Cells/MethodCell.swift
+++ b/Example/PinLayoutSample/UI/Examples/TableViewExample/Cells/MethodCell.swift
@@ -61,7 +61,7 @@ class MethodCell: UITableViewCell {
     
     private func layout() {
         iconImageView.pin.top().left().size(30).margin(padding)
-        nameLabel.pin.right(of: iconImageView, aligned: .center).right().marginHorizontal(padding).sizeToFit(.width)
+        nameLabel.pin.after(of: iconImageView, aligned: .center).right().marginHorizontal(padding).sizeToFit(.width)
         descriptionLabel.pin.below(of: [iconImageView, nameLabel]).horizontally().margin(padding).sizeToFit(.width)
     }
     

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Luc Dion
+Copyright (c) 2017-2018 Luc Dion
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PinLayout.podspec
+++ b/PinLayout.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |spec|
   spec.name          = "PinLayout"
-  spec.version       = "1.7.12"
+  spec.version       = "1.8.0"
   spec.summary       = "Fast Swift Views layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable. [iOS/macOS/tvOS/CALayer]"
   spec.description   = "Fast Swift Views layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable. [iOS/macOS/tvOS/CALayer]"
   spec.homepage      = "https://github.com/layoutBox/PinLayout"

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Nimble (7.0.3)
-  - PinLayout (1.7.11)
+  - PinLayout (1.7.12)
   - Quick (1.2.0)
   - Reveal-SDK (17)
-  - SwiftLint (0.25.1)
+  - SwiftLint (0.27.0)
 
 DEPENDENCIES:
   - Nimble
@@ -13,7 +13,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - Nimble
     - Quick
     - Reveal-SDK
@@ -25,11 +25,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Nimble: 7f5a9c447a33002645a071bddafbfb24ea70e0ac
-  PinLayout: 90c26ecc9504e35c6569a65d78dc50853d96f08c
+  PinLayout: 4922b1c70da60d5bff2e7fb4116deb1ddc759927
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   Reveal-SDK: a6df49f47319bd19a110c960c498af32df72c0af
-  SwiftLint: ce933681be10c3266e82576dad676fa815a602e9
+  SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
 
 PODFILE CHECKSUM: 62618887f8155abc1ed3348d9b676cf6915137e2
 
-COCOAPODS: 1.5.0
+COCOAPODS: 1.5.3

--- a/README.md
+++ b/README.md
@@ -474,20 +474,24 @@ Position the view left of the specified view(s) and aligned it using the specifi
 Position the view right of the specified view(s) and aligned it using the specified VerticalAlignment. Similar to `after(of:)`. One or many relative views can be specified. This method is similar to pinning one view’s anchor: topLeft, centerLeft or bottomLeft.
 
 
-**How alignment is applied:**
+**How HorizontalAlignment is applied:**
 
-* **`HorizontalAlignment.left`**: The view's left edge will be aligned to the left most relative view.
-* **`HorizontalAlignment.center`**: The view's hCenter edge will be aligned with the average hCenter of all relative views.
-*  **`HorizontalAlignment.right`**: The view's right edge will be aligned to the right most relative view.
+* **`HorizontalAlignment.left`**: The view's left edge will be left-aligned with the relative view (or the left most view if a list of relative views is specified).
+* **`HorizontalAlignment.center`**: The view's will be horizontally centered with the relative view (or the average hCenter if a list of relative views is used).
+*  **`HorizontalAlignment.right`**: The view's right edge will be right-aligned with the relative view (or the right most view if a list of relative views is specified).
 * **`HorizontalAlignment.start`**:left_right_arrow::  
-In LTR direction the view's left edge will be aligned to the left most relative view.  
-In RTL direction the view's right edge will be aligned to the right most relative view.
+In LTR direction, similar to using HorizontalAlignment.left.
+In RTL direction, similar to using HorizontalAlignment.right.
 * **`HorizontalAlignment.end`**:left_right_arrow::  
-In LTR direction the view's right edge will be aligned to the right most relative view.  
-In RTL direction the view's left edge will be aligned to the right most relative view.
-*  **`VerticalAlignment.top`**: The view's top edge will be aligned to the top most relative view.
-*  **`VerticalAlignment.center`**: The view's vCenter edge will be aligned with the average vCenter of all relative views.
-*  **`VerticalAlignment.bottom`**: The view's bottom edge will be aligned to the bottom most relative view.
+In LTR direction, similar to using HorizontalAlignment.right.
+In RTL direction, similar to using HorizontalAlignment.left.
+
+**How VerticalAlignment is applied:**
+
+
+*  **`VerticalAlignment.top`**: The view's top edge will be top-aligned with the relative view (or the top most view if a list of relative views is specified).
+*  **`VerticalAlignment.center`**: The view's will be vertically centered with the relative view (or the average vCenter if a list of relative views is used).
+*  **`VerticalAlignment.bottom`**: The view's bottom edge will be bottom-aligned with the relative view (or the bottom most view if a list of relative views is specified).
 
 :pushpin: **Multiple relative views**: If for example a call to `below(of: [...], aligned:) specify multiple relative views, the view will be layouted below *ALL* these views. The alignment will be applied using all relative view
 
@@ -1726,6 +1730,10 @@ PinLayout was inspired by other great layout frameworks, including:
 
 ## History
 PinLayout recent history is available in the [CHANGELOG](CHANGELOG.md) also in [GitHub Releases](https://github.com/layoutBox/PinLayout/releases).
+
+### Recent breaking change
+
+* `fitSize()` has been removed after being deprecated for 10 months. `sizeToFit(...)` should now be used instead. See [Adjusting size](#adjusting_size). (2018-08-21)
 
 <br>
 

--- a/Sources/Impl/Coordinates.swift
+++ b/Sources/Impl/Coordinates.swift
@@ -30,8 +30,16 @@ internal var displayScale: CGFloat = NSScreen.main?.backingScaleFactor ?? 2.0
 #endif
 internal var onePixelLength: CGFloat = 1 / displayScale
 
-public func _pinlayoutSetUnitTest(scale: CGFloat) {
-    displayScale = scale
+public func _pinlayoutSetUnitTest(scale: CGFloat?) {
+    if let scale = scale {
+        displayScale = scale
+    } else {
+        #if os(iOS) || os(tvOS)
+        displayScale = UIScreen.main.scale
+        #elseif os(OSX)
+        displayScale = NSScreen.main?.backingScaleFactor ?? 2.0
+        #endif
+    }
 }
 
 final class Coordinates<View: Layoutable> {

--- a/Sources/Impl/PinLayout+Layouting.swift
+++ b/Sources/Impl/PinLayout+Layouting.swift
@@ -203,8 +203,6 @@ extension PinLayout {
                 size = computeSizeToFit(adjustSizeType: adjustSizeType, size: size)
             case .sizeToFit:
                 size = computeSizeToFit(size: size)
-            case .fitSizeLegacy:
-                size = computeLegacyFitSize(size: size)
             case .aspectRatio(let ratio):
                 size = computeAspectRatio(ratio, size: size)
             }
@@ -247,44 +245,6 @@ extension PinLayout {
 
         let viewRect = view.getRect(keepTransform: keepTransform)
         return Size(width: viewRect.width, height: viewRect.height)
-    }
-
-    private func computeLegacyFitSize(size: Size) -> Size {
-        guard let sizeCalculableView = view as? SizeCalculable else {
-            assertionFailure("Should not occurs, protocol conformance is checked before assigning adjustSizeType")
-            return size
-        }
-        guard size.width != nil || size.height != nil else {
-            warn("fitSize() won't be applied, neither the width nor the height can be determined.")
-            return size
-        }
-
-        var size = size
-        var fitWidth = CGFloat.greatestFiniteMagnitude
-        var fitHeight = CGFloat.greatestFiniteMagnitude
-
-        if let width = applyMinMax(toWidth: size.width) {
-            fitWidth = width
-        }
-        if let height = applyMinMax(toHeight: size.height) {
-            fitHeight = height
-        }
-
-        let sizeThatFits = sizeCalculableView.sizeThatFits(CGSize(width: fitWidth, height: fitHeight))
-
-        if fitWidth != .greatestFiniteMagnitude && (sizeThatFits.width > fitWidth) {
-            size.width = fitWidth
-        } else {
-            size.width = sizeThatFits.width
-        }
-
-        if fitHeight != .greatestFiniteMagnitude && (sizeThatFits.height > fitHeight) {
-            size.height = fitHeight
-        } else {
-            size.height = sizeThatFits.height
-        }
-
-        return size
     }
 
     private func computeSizeToFit(adjustSizeType: AdjustSizeType, size: Size) -> Size {
@@ -389,7 +349,7 @@ extension PinLayout {
         let remainingWidth = containerWidth - rect.width
         var justifyType = HorizontalAlign.left
         
-        if let justify = justify {
+        if let justify = justify, justify != .none {
             justifyType = justify
         }
         
@@ -415,6 +375,8 @@ extension PinLayout {
             } else {
                 rect.origin.x = left + _marginLeft
             }
+        case .none:
+            break
         }
         
         return rect
@@ -441,7 +403,7 @@ extension PinLayout {
         let remainingHeight = containerHeight - rect.height
         var alignType = VerticalAlign.top
         
-        if let align = align {
+        if let align = align, align != .none {
             alignType = align
         }
         
@@ -454,6 +416,8 @@ extension PinLayout {
             rect.origin.y = top + _marginTop + remainingHeight / 2
         case .bottom:
             rect.origin.y = bottom - _marginBottom - rect.height
+        case .none:
+            break
         }
         
         return rect

--- a/Sources/PinLayout+Relative.swift
+++ b/Sources/PinLayout+Relative.swift
@@ -29,26 +29,14 @@ extension PinLayout {
     // above(of ...)
     //
     @discardableResult
-    public func above(of relativeView: View) -> PinLayout {
-        func context() -> String { return "above(of: \(relativeView))" }
-        return above(relativeViews: [relativeView], aligned: nil, context: context)
-    }
-
-    @discardableResult
-    public func above(of relativeViews: [View]) -> PinLayout {
-        func context() -> String { return "above(of: \(relativeViews))" }
-        return above(relativeViews: relativeViews, aligned: nil, context: context)
-    }
-
-    @discardableResult
-    public func above(of relativeView: View, aligned: HorizontalAlign) -> PinLayout {
-        func context() -> String { return "above(of: \(relativeView), aligned: \(aligned))" }
+    public func above(of relativeView: View, aligned: HorizontalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("above", relativeView, aligned) }
         return above(relativeViews: [relativeView], aligned: aligned, context: context)
     }
 
     @discardableResult
-    public func above(of relativeViews: [View], aligned: HorizontalAlign) -> PinLayout {
-        func context() -> String { return "above(of: \(relativeViews), aligned: \(aligned))" }
+    public func above(of relativeViews: [View], aligned: HorizontalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("above", relativeViews, aligned) }
         return above(relativeViews: relativeViews, aligned: aligned, context: context)
     }
     
@@ -56,26 +44,14 @@ extension PinLayout {
     // below(of ...)
     //
     @discardableResult
-    public func below(of relativeView: View) -> PinLayout {
-        func context() -> String { return "below(of: \(relativeView))" }
-        return below(relativeViews: [relativeView], aligned: nil, context: context)
-    }
-
-    @discardableResult
-    public func below(of relativeViews: [View]) -> PinLayout {
-        func context() -> String { return "below(of: \(relativeViews))" }
-        return below(relativeViews: relativeViews, aligned: nil, context: context)
-    }
-
-    @discardableResult
-    public func below(of relativeView: View, aligned: HorizontalAlign) -> PinLayout {
-        func context() -> String { return "below(of: \(relativeView), aligned: \(aligned))" }
+    public func below(of relativeView: View, aligned: HorizontalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("below", relativeView, aligned) }
         return below(relativeViews: [relativeView], aligned: aligned, context: context)
     }
 
     @discardableResult
-    public func below(of relativeViews: [View], aligned: HorizontalAlign) -> PinLayout {
-        func context() -> String { return "below(of: \(relativeViews), aligned: \(aligned))" }
+    public func below(of relativeViews: [View], aligned: HorizontalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("below", relativeViews, aligned) }
         return below(relativeViews: relativeViews, aligned: aligned, context: context)
     }
     
@@ -83,26 +59,14 @@ extension PinLayout {
     // left(of ...)
     //
     @discardableResult
-    public func left(of relativeView: View) -> PinLayout {
-        func context() -> String { return "left(of: \(relativeView))" }
-        return left(relativeViews: [relativeView], aligned: nil, context: context)
-    }
-
-    @discardableResult
-    public func left(of relativeViews: [View]) -> PinLayout {
-        func context() -> String { return "left(of: \(relativeViews))" }
-        return left(relativeViews: relativeViews, aligned: nil, context: context)
-    }
-
-    @discardableResult
-    public func left(of relativeView: View, aligned: VerticalAlign) -> PinLayout {
-        func context() -> String { return "left(of: \(relativeView), aligned: \(aligned))" }
+    public func left(of relativeView: View, aligned: VerticalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("left", relativeView, aligned) }
         return left(relativeViews: [relativeView], aligned: aligned, context: context)
     }
 
     @discardableResult
-    public func left(of relativeViews: [View], aligned: VerticalAlign) -> PinLayout {
-        func context() -> String { return "left(of: \(relativeViews), aligned: \(aligned))" }
+    public func left(of relativeViews: [View], aligned: VerticalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("left", relativeViews, aligned) }
         return left(relativeViews: relativeViews, aligned: aligned, context: context)
     }
 
@@ -110,52 +74,23 @@ extension PinLayout {
     // right(of ...)
     //
     @discardableResult
-    public func right(of relativeView: View) -> PinLayout {
-        func context() -> String { return "right(of: \(relativeView))" }
-        return right(relativeViews: [relativeView], aligned: nil, context: context)
-    }
-
-    @discardableResult
-    public func right(of relativeViews: [View]) -> PinLayout {
-        func context() -> String { return "right(of: \(relativeViews))" }
-        return right(relativeViews: relativeViews, aligned: nil, context: context)
-    }
-
-    @discardableResult
-    public func right(of relativeView: View, aligned: VerticalAlign) -> PinLayout {
-        func context() -> String { return "right(of: \(relativeView), aligned: \(aligned))" }
+    public func right(of relativeView: View, aligned: VerticalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("right", relativeView, aligned) }
         return right(relativeViews: [relativeView], aligned: aligned, context: context)
     }
 
     @discardableResult
-    public func right(of relativeViews: [View], aligned: VerticalAlign) -> PinLayout {
-        func context() -> String { return "right(of: \(relativeViews), aligned: \(aligned))" }
+    public func right(of relativeViews: [View], aligned: VerticalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("right", relativeViews, aligned) }
         return right(relativeViews: relativeViews, aligned: aligned, context: context)
     }
 
+    //
+    // before(of ...)
+    //
     @discardableResult
-    public func before(of relativeView: View) -> PinLayout {
-        func context() -> String { return "before(of: \(relativeView))" }
-        if isLTR() {
-            return left(relativeViews: [relativeView], aligned: nil, context: context)
-        } else {
-            return right(relativeViews: [relativeView], aligned: nil, context: context)
-        }
-    }
-
-    @discardableResult
-    public func before(of relativeViews: [View]) -> PinLayout {
-        func context() -> String { return "before(of: \(relativeViews))" }
-        if isLTR() {
-            return left(relativeViews: relativeViews, aligned: nil, context: context)
-        } else {
-            return right(relativeViews: relativeViews, aligned: nil, context: context)
-        }
-    }
-
-    @discardableResult
-    public func before(of relativeView: View, aligned: VerticalAlign) -> PinLayout {
-        func context() -> String { return "before(of: \(relativeView), aligned: \(aligned))" }
+    public func before(of relativeView: View, aligned: VerticalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("before", relativeView, aligned) }
         if isLTR() {
             return left(relativeViews: [relativeView], aligned: aligned, context: context)
         } else {
@@ -164,8 +99,8 @@ extension PinLayout {
     }
 
     @discardableResult
-    public func before(of relativeViews: [View], aligned: VerticalAlign) -> PinLayout {
-        func context() -> String { return "before(of: \(relativeViews), aligned: \(aligned))" }
+    public func before(of relativeViews: [View], aligned: VerticalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("before", relativeViews, aligned) }
         if isLTR() {
             return left(relativeViews: relativeViews, aligned: aligned, context: context)
         } else {
@@ -173,29 +108,12 @@ extension PinLayout {
         }
     }
 
+    //
+    // after(of ...)
+    //
     @discardableResult
-    public func after(of relativeView: View) -> PinLayout {
-        func context() -> String { return "after(of: \(relativeView))" }
-        if isLTR() {
-            return right(relativeViews: [relativeView], aligned: nil, context: context)
-        } else {
-            return left(relativeViews: [relativeView], aligned: nil, context: context)
-        }
-    }
-
-    @discardableResult
-    public func after(of relativeViews: [View]) -> PinLayout {
-        func context() -> String { return "after(of: \(relativeViews))" }
-        if isLTR() {
-            return right(relativeViews: relativeViews, aligned: nil, context: context)
-        } else {
-            return left(relativeViews: relativeViews, aligned: nil, context: context)
-        }
-    }
-
-    @discardableResult
-    public func after(of relativeView: View, aligned: VerticalAlign) -> PinLayout {
-        func context() -> String { return "after(of: \(relativeView))" }
+    public func after(of relativeView: View, aligned: VerticalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("after", relativeView, aligned) }
         if isLTR() {
             return right(relativeViews: [relativeView], aligned: aligned, context: context)
         } else {
@@ -204,8 +122,8 @@ extension PinLayout {
     }
 
     @discardableResult
-    public func after(of relativeViews: [View], aligned: VerticalAlign) -> PinLayout {
-        func context() -> String { return "after(of: \(relativeViews), aligned: \(aligned))" }
+    public func after(of relativeViews: [View], aligned: VerticalAlign = .none) -> PinLayout {
+        func context() -> String { return relativeContext("after", relativeViews, aligned) }
         if isLTR() {
             return right(relativeViews: relativeViews, aligned: aligned, context: context)
         } else {
@@ -216,22 +134,19 @@ extension PinLayout {
 
 // MARK: private
 extension PinLayout {
-    private func above(relativeViews: [View], aligned: HorizontalAlign?, context: Context) -> PinLayout {
+    private func above(relativeViews: [View], aligned: HorizontalAlign, context: Context) -> PinLayout {
         guard let relativeViews = validateRelativeViews(relativeViews, context: context) else { return self }
         
         let anchors: [Anchor]
-        if let aligned = aligned {
-            switch aligned {
-            case .left:   anchors = relativeViews.map({ $0.anchor.topLeft })
-            case .center: anchors = relativeViews.map({ $0.anchor.topCenter })
-            case .right:  anchors = relativeViews.map({ $0.anchor.topRight })
-            case .start:  anchors = isLTR() ? relativeViews.map({ $0.anchor.topLeft }) : relativeViews.map({ $0.anchor.topRight })
-            case .end:    anchors = isLTR() ? relativeViews.map({ $0.anchor.topRight }) : relativeViews.map({ $0.anchor.topLeft })
-            }
-        } else {
-            anchors = relativeViews.map({ $0.anchor.topLeft })
+        switch aligned {
+        case .left:   anchors = relativeViews.map({ $0.anchor.topLeft })
+        case .center: anchors = relativeViews.map({ $0.anchor.topCenter })
+        case .right:  anchors = relativeViews.map({ $0.anchor.topRight })
+        case .start:  anchors = isLTR() ? relativeViews.map({ $0.anchor.topLeft }) : relativeViews.map({ $0.anchor.topRight })
+        case .end:    anchors = isLTR() ? relativeViews.map({ $0.anchor.topRight }) : relativeViews.map({ $0.anchor.topLeft })
+        case .none:   anchors = relativeViews.map({ $0.anchor.topLeft })
         }
-        
+
         if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
             setBottom(getTopMostCoordinate(list: coordinatesList), context)
             applyHorizontalAlignment(aligned, coordinatesList: coordinatesList, context: context)
@@ -239,22 +154,19 @@ extension PinLayout {
         return self
     }
 
-    private func below(relativeViews: [View], aligned: HorizontalAlign?, context: Context) -> PinLayout {
+    private func below(relativeViews: [View], aligned: HorizontalAlign, context: Context) -> PinLayout {
         guard let relativeViews = validateRelativeViews(relativeViews, context: context) else { return self }
         
         let anchors: [Anchor]
-        if let aligned = aligned {
-            switch aligned {
-            case .left:   anchors = relativeViews.map({ $0.anchor.bottomLeft })
-            case .center: anchors = relativeViews.map({ $0.anchor.bottomCenter })
-            case .right:  anchors = relativeViews.map({ $0.anchor.bottomRight })
-            case .start:  anchors = isLTR() ? relativeViews.map({ $0.anchor.bottomLeft }) : relativeViews.map({ $0.anchor.bottomRight })
-            case .end:    anchors = isLTR() ? relativeViews.map({ $0.anchor.bottomRight }) : relativeViews.map({ $0.anchor.bottomLeft })
-            }
-        } else {
-            anchors = relativeViews.map({ $0.anchor.bottomLeft })
+        switch aligned {
+        case .left:   anchors = relativeViews.map({ $0.anchor.bottomLeft })
+        case .center: anchors = relativeViews.map({ $0.anchor.bottomCenter })
+        case .right:  anchors = relativeViews.map({ $0.anchor.bottomRight })
+        case .start:  anchors = isLTR() ? relativeViews.map({ $0.anchor.bottomLeft }) : relativeViews.map({ $0.anchor.bottomRight })
+        case .end:    anchors = isLTR() ? relativeViews.map({ $0.anchor.bottomRight }) : relativeViews.map({ $0.anchor.bottomLeft })
+        case .none:   anchors = relativeViews.map({ $0.anchor.bottomLeft })
         }
-        
+
         if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
             setTop(getBottomMostCoordinate(list: coordinatesList), context)
             applyHorizontalAlignment(aligned, coordinatesList: coordinatesList, context: context)
@@ -262,20 +174,17 @@ extension PinLayout {
         return self
     }
     
-    private func left(relativeViews: [View], aligned: VerticalAlign?, context: Context) -> PinLayout {
+    private func left(relativeViews: [View], aligned: VerticalAlign, context: Context) -> PinLayout {
         guard let relativeViews = validateRelativeViews(relativeViews, context: context) else { return self }
         
         let anchors: [Anchor]
-        if let aligned = aligned {
-            switch aligned {
-            case .top:    anchors = relativeViews.map({ $0.anchor.topLeft })
-            case .center: anchors = relativeViews.map({ $0.anchor.centerLeft })
-            case .bottom: anchors = relativeViews.map({ $0.anchor.bottomLeft })
-            }
-        } else {
-            anchors = relativeViews.map({ $0.anchor.topLeft })
+        switch aligned {
+        case .top:    anchors = relativeViews.map({ $0.anchor.topLeft })
+        case .center: anchors = relativeViews.map({ $0.anchor.centerLeft })
+        case .bottom: anchors = relativeViews.map({ $0.anchor.bottomLeft })
+        case .none:   anchors = relativeViews.map({ $0.anchor.topLeft })
         }
-        
+
         if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
             setRight(getLeftMostCoordinate(list: coordinatesList), context)
             applyVerticalAlignment(aligned, coordinatesList: coordinatesList, context: context)
@@ -283,18 +192,15 @@ extension PinLayout {
         return self
     }
     
-    private func right(relativeViews: [View], aligned: VerticalAlign?, context: Context) -> PinLayout {
+    private func right(relativeViews: [View], aligned: VerticalAlign, context: Context) -> PinLayout {
         guard let relativeViews = validateRelativeViews(relativeViews, context: context) else { return self }
         
         let anchors: [Anchor]
-        if let aligned = aligned {
-            switch aligned {
-            case .top:    anchors = relativeViews.map({ $0.anchor.topRight })
-            case .center: anchors = relativeViews.map({ $0.anchor.centerRight })
-            case .bottom: anchors = relativeViews.map({ $0.anchor.bottomRight })
-            }
-        } else {
-            anchors = relativeViews.map({ $0.anchor.topRight })
+        switch aligned {
+        case .top:    anchors = relativeViews.map({ $0.anchor.topRight })
+        case .center: anchors = relativeViews.map({ $0.anchor.centerRight })
+        case .bottom: anchors = relativeViews.map({ $0.anchor.bottomRight })
+        case .none:   anchors = relativeViews.map({ $0.anchor.topRight })
         }
         
         if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
@@ -305,29 +211,28 @@ extension PinLayout {
     }
     
     private func applyHorizontalAlignment(_ aligned: HorizontalAlign?, coordinatesList: [CGPoint], context: Context) {
-        if let aligned = aligned {
-            switch aligned {
-            case .left:   setLeft(getLeftMostCoordinate(list: coordinatesList), context)
-            case .center: setHorizontalCenter(getAverageHCenterCoordinate(list: coordinatesList), context)
-            case .right:  setRight(getRightMostCoordinate(list: coordinatesList), context)
-                
-            case .start:
-                isLTR() ? setLeft(getLeftMostCoordinate(list: coordinatesList), context) :
-                          setRight(getRightMostCoordinate(list: coordinatesList), context)
-            case .end:
-                isLTR() ? setRight(getRightMostCoordinate(list: coordinatesList), context) :
-                          setLeft(getLeftMostCoordinate(list: coordinatesList), context)
-            }
+        guard let aligned = aligned, aligned != .none else { return }
+        switch aligned {
+        case .left:   setLeft(getLeftMostCoordinate(list: coordinatesList), context)
+        case .center: setHorizontalCenter(getAverageHCenterCoordinate(list: coordinatesList), context)
+        case .right:  setRight(getRightMostCoordinate(list: coordinatesList), context)
+        case .start:
+            isLTR() ? setLeft(getLeftMostCoordinate(list: coordinatesList), context) :
+                      setRight(getRightMostCoordinate(list: coordinatesList), context)
+        case .end:
+            isLTR() ? setRight(getRightMostCoordinate(list: coordinatesList), context) :
+                      setLeft(getLeftMostCoordinate(list: coordinatesList), context)
+        case .none:   break
         }
     }
     
     private func applyVerticalAlignment(_ aligned: VerticalAlign?, coordinatesList: [CGPoint], context: Context) {
-        if let aligned = aligned {
-            switch aligned {
-            case .top:    setTop(getTopMostCoordinate(list: coordinatesList), context)
-            case .center: setVerticalCenter(getAverageVCenterCoordinate(list: coordinatesList), context)
-            case .bottom: setBottom(getBottomMostCoordinate(list: coordinatesList), context)
-            }
+        guard let aligned = aligned, aligned != .none else { return }
+        switch aligned {
+        case .top:    setTop(getTopMostCoordinate(list: coordinatesList), context)
+        case .center: setVerticalCenter(getAverageVCenterCoordinate(list: coordinatesList), context)
+        case .bottom: setBottom(getBottomMostCoordinate(list: coordinatesList), context)
+        case .none:   break
         }
     }
     
@@ -387,5 +292,29 @@ extension PinLayout {
         }
         
         return relativeViews
+    }
+
+    private func relativeContext(_ type: String, _ relativeView: View, _ aligned: VerticalAlign?) -> String {
+        return relativeContext(type, "\(relativeView)", aligned: aligned == VerticalAlign.none ? nil : aligned?.description)
+    }
+
+    private func relativeContext(_ type: String, _ relativeViews: [View], _ aligned: VerticalAlign?) -> String {
+        return relativeContext(type, "\(relativeViews)", aligned: aligned == VerticalAlign.none ? nil : aligned?.description)
+    }
+
+    private func relativeContext(_ type: String, _ relativeView: View, _ aligned: HorizontalAlign?) -> String {
+        return relativeContext(type, "\(relativeView)", aligned: aligned == HorizontalAlign.none ? nil : aligned?.description)
+    }
+
+    private func relativeContext(_ type: String, _ relativeViews: [View], _ aligned: HorizontalAlign?) -> String {
+        return relativeContext(type, "\(relativeViews)", aligned: aligned == HorizontalAlign.none ? nil : aligned?.description)
+    }
+
+    private func relativeContext(_ type: String, _ relativeView: String, aligned: String?) -> String {
+        if let aligned = aligned {
+            return "\(type)(of: \(relativeView), aligned: .\(aligned))"
+        } else {
+            return "\(type)(of: \(relativeView))"
+        }
     }
 }

--- a/Sources/PinLayout+Size.swift
+++ b/Sources/PinLayout+Size.swift
@@ -31,7 +31,6 @@ enum AdjustSizeType {
 
     case sizeToFit
 
-    case fitSizeLegacy
     case aspectRatio(CGFloat)
 
     var isFlexible: Bool {
@@ -48,7 +47,7 @@ enum AdjustSizeType {
         switch self {
         case .fitTypeWidth, .fitTypeHeight,
              .fitTypeWidthFlexible, .fitTypeHeightFlexible,
-             .sizeToFit, .fitSizeLegacy:
+             .sizeToFit:
             return true
         case .aspectRatio(_):
             return false
@@ -225,14 +224,6 @@ extension PinLayout {
     public func sizeToFit() -> PinLayout {
         return setAdjustSizeType(.sizeToFit, { return "sizeToFit()" })
     }
-
-    #if os(iOS) || os(tvOS)
-    @available(*, deprecated, message: "fitSize() is deprecated, please use sizeToFit(fitType: FitType)")
-    @discardableResult
-    public func fitSize() -> PinLayout {
-        return setAdjustSizeType(.fitSizeLegacy, { return "fitSize()" })
-    }
-    #endif
 }
 
 //
@@ -273,8 +264,6 @@ extension PinLayout {
             conflict = "sizeToFit(\(adjustSizeType.toFitType()!.description))."
         case .sizeToFit:
             conflict = "sizeToFit()"
-        case .fitSizeLegacy:
-            conflict = "fitSize()"
         case .aspectRatio(let ratio):
             conflict = "aspectRatio(\(ratio))"
         }

--- a/Sources/Types+Description.swift
+++ b/Sources/Types+Description.swift
@@ -31,6 +31,7 @@ extension HorizontalAlign {
         case .right: return "right"
         case .start: return "start"
         case .end: return "end"
+        case .none: return "none"
         }
     }
 }
@@ -41,6 +42,7 @@ extension VerticalAlign {
         case .top: return "top"
         case .center: return "center"
         case .bottom: return "bottom"
+        case .none: return "none"
         }
     }
 }

--- a/Sources/Types.swift
+++ b/Sources/Types.swift
@@ -99,30 +99,43 @@ import Foundation
     var end: HorizontalEdge { get }
 }
 
-/// Horizontal alignment used with relative positionning methods: above(of relativeView:, aligned:), below(of relativeView:, aligned:)
+/// Horizontal alignment used with relative positionning methods: above(of relativeView:, aligned:), below(of relativeView:, aligned:), ...
 ///
 /// - left: left aligned
 /// - center: center aligned
 /// - right: right aligned
 @objc public enum HorizontalAlign: Int {
+    /// The view's left edge will be left-aligned with the relative view (or the left most view if a list of relative views is specified).
     case left
+    /// The view's will be horizontally centered with the relative view (or the average hCenter if a list of relative views is used).
     case center
+    /// The view's right edge will be right-aligned with the relative view (or the right most view if a list of relative views is specified).
     case right
-
+    /// No alignment will be applied.
+    case none
     // RTL support
+    /// In LTR direction, similar to using HorizontalAlignment.left.
+    /// In RTL direction, similar to using HorizontalAlignment.right.
     case start
+    /// In LTR direction, similar to using HorizontalAlignment.right.
+    /// In RTL direction, similar to using HorizontalAlignment.left.
     case end
 }
 
-/// Vertical alignment used with relative positionning methods: left(of relativeView:, aligned:), right(of relativeView:, aligned:)
+/// Vertical alignment used with relative positionning methods: after(of relativeView:, aligned:), before(of relativeView:, aligned:), ...
 ///
 /// - top: top aligned
 /// - center: center aligned
 /// - bottom: bottom aligned
 @objc public enum VerticalAlign: Int {
+    /// The view's top edge will be top-aligned with the relative view (or the top most view if a list of relative views is specified).
     case top
+    /// The view's will be vertically centered with the relative view (or the average vCenter if a list of relative views is used).
     case center
+    /// The view's bottom edge will be bottom-aligned with the relative view (or the bottom most view if a list of relative views is specified).
     case bottom
+    /// No alignment will be applied.
+    case none
 }
 
 /// UIView's horizontal edges (left/right) definition

--- a/Tests/Common/CALayerSpec.swift
+++ b/Tests/Common/CALayerSpec.swift
@@ -36,11 +36,8 @@ class CALayerSpec: QuickSpec {
             bLayer
          */
 
-        beforeSuite {
-            _pinlayoutSetUnitTest(scale: 2)
-        }
-
         beforeEach {
+            _pinlayoutSetUnitTest(scale: 2)
             Pin.lastWarningText = nil
             Pin.logMissingLayoutCalls = false
 
@@ -72,6 +69,7 @@ class CALayerSpec: QuickSpec {
         }
 
         afterEach {
+            _pinlayoutSetUnitTest(scale: nil)
             Pin.logMissingLayoutCalls = false
         }
 

--- a/Tests/Common/RelativePositionMultipleViewsSpec.swift
+++ b/Tests/Common/RelativePositionMultipleViewsSpec.swift
@@ -46,8 +46,9 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
         */
 
         beforeEach {
+            _pinlayoutSetUnitTest(scale: 2)
             Pin.lastWarningText = nil
-            
+
             viewController = PViewController()
             viewController.view = BasicView()
             
@@ -71,6 +72,10 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             bViewChild.frame = CGRect(x: 40, y: 10, width: 60, height: 20)
             bView.addSubview(bViewChild)
         }
+
+        afterEach {
+            _pinlayoutSetUnitTest(scale: nil)
+        }
         
         //
         // above(of: UIViews.....) warnings
@@ -80,7 +85,14 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
                 let unatachedView = PView()
                 bViewChild.pin.above(of: unatachedView)
                 expect(bViewChild.frame).to(equal(CGRect(x: 40, y: 10, width: 60, height: 20)))
-                expect(Pin.lastWarningText).to(contain(["above", "won't be applied", "no valid references"]))
+                expect(Pin.lastWarningText).to(contain(["above(of: ", ")", "won't be applied", "no valid references"]))
+            }
+
+            it("should warns the view bottom edge") {
+                let unatachedView = PView()
+                bViewChild.pin.above(of: unatachedView, aligned: .left)
+                expect(bViewChild.frame).to(equal(CGRect(x: 40, y: 10, width: 60, height: 20)))
+                expect(Pin.lastWarningText).to(contain(["above(of: ", ", aligned: .left)", "won't be applied", "no valid references"]))
             }
             
             it("should warns the view bottom edge") {
@@ -94,7 +106,14 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
                 let unatachedView = PView()
                 bViewChild.pin.above(of: [aView, unatachedView])
                 expect(bViewChild.frame).to(equal(CGRect(x: 40.0, y: -40.0, width: 60.0, height: 20.0)))
-                expect(Pin.lastWarningText).to(contain(["above", "won't be applied", "the reference view", "must be added", "as a reference"]))
+                expect(Pin.lastWarningText).to(contain(["above(of: [", "])", "won't be applied", "the reference view", "must be added", "as a reference"]))
+            }
+
+            it("Should warn, but the view should be anyway layout it above") {
+                let unatachedView = PView()
+                bViewChild.pin.above(of: [aView, unatachedView], aligned: .center)
+                expect(bViewChild.frame).to(equal(CGRect(x: -100.0, y: -40.0, width: 60.0, height: 20.0)))
+                expect(Pin.lastWarningText).to(contain(["above(of: [", "], aligned: .center)", "won't be applied", "the reference view", "must be added", "as a reference"]))
             }
         }
         

--- a/docs/xcode_playground.md
+++ b/docs/xcode_playground.md
@@ -16,7 +16,7 @@ The method will execute PinLayout commands immediately. This method is **require
 
 ```swift
     view.pin.top(20).bottom(20).width(100).layout()
-    view2.pin.below(of: view).left().right().layout()
+    view2.pin.below(of: view).horizontally().layout()
 ```
 
 **TIP**: If your codes needs to work in Xcode playgrounds, you may set to `true` the property `Pin.logMissingLayoutCalls`, this way any missing call to `layout()` will generate a warning in the Xcode console.


### PR DESCRIPTION
`fitSize()` has been removed after being deprecated for 10 months. `sizeToFit(:FitType)` should now be used instead.

Plus:
* Refactor relative positioning methods source code (above(...), after(...), ...) using a default parameter value for the alignment parameter.
* Fix unit test screen density.
* Update few examples source code.