### PR TITLE
Update Package.swift for Xcode 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,13 @@
-// swift-tools-version:3.1
+// swift-tools-version:4.0
 
 import PackageDescription
 
 let package = Package(
     name: "PinLayout",
-    exclude: ["Tests"]
+    products: [
+        .library(name: "PinLayout", targets: ["PinLayout"])
+    ],
+    targets: [
+        .target(name: "PinLayout", path: "Sources")
+    ]
 )


### PR DESCRIPTION
Updated Package.swift to allow PinLayout to be used with Xcode 11's Swift Package Manager support.