### PR TITLE
Fix XCode 10.2 warnings

### DIFF
--- a/Sources/Extensions/PEdgeInsets+Operators.swift
+++ b/Sources/Extensions/PEdgeInsets+Operators.swift
@@ -5,14 +5,14 @@ import AppKit
 #endif
 
 public extension PEdgeInsets {
-    public func minInsets(_ insets: PEdgeInsets) -> PEdgeInsets {
+    func minInsets(_ insets: PEdgeInsets) -> PEdgeInsets {
         return PEdgeInsets(top: minValue(self.top, minValue: insets.top),
                            left: minValue(self.left, minValue: insets.left),
                            bottom: minValue(self.bottom, minValue: insets.bottom),
                            right: minValue(self.right, minValue: insets.right))
     }
 
-    public func minInsets(dx: CGFloat, dy: CGFloat) -> PEdgeInsets {
+    func minInsets(dx: CGFloat, dy: CGFloat) -> PEdgeInsets {
         return PEdgeInsets(top: minValue(self.top, minValue: dy),
                            left: minValue(self.left, minValue: dx),
                            bottom: minValue(self.bottom, minValue: dy),


### PR DESCRIPTION
>'public' modifier is redundant for instance method declared in a public extension