### PR TITLE
Use effectiveUserInterfaceLayoutDirection

### DIFF
--- a/Sources/Extensions/UIView+PinLayout.swift
+++ b/Sources/Extensions/UIView+PinLayout.swift
@@ -80,7 +80,9 @@ extension UIView: Layoutable, SizeCalculable {
     public func isLTR() -> Bool {
         switch Pin.layoutDirection {
         case .auto:
-            if #available(iOS 9.0, *) {
+            if #available(iOS 10.0, tvOS 10.0, *) {
+                return effectiveUserInterfaceLayoutDirection == .leftToRight
+            } else if #available(iOS 9.0, *) {
                 return UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .leftToRight
             } else if let shared = UIApplication.value(forKey: "sharedApplication") as? UIApplication {
                 return shared.userInterfaceLayoutDirection == .leftToRight


### PR DESCRIPTION
Use effectiveUserInterfaceLayoutDirection to detect RTL on iOS 10 and
above. This is recommended approach to detect layout direction taking
into account view's semantic content attribute, trait environment and
UIApplication layout direction

More info here: https://developer.apple.com/videos/play/wwdc2016/232/?time=1027