### PR TITLE
Improve method that validates `width` and `height` values

### DIFF
--- a/Example/PinLayoutSample.xcodeproj/project.pbxproj
+++ b/Example/PinLayoutSample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -516,7 +516,7 @@
 				};
 			};
 			buildConfigurationList = 249EFE3A1E64FAFE00165E39 /* Build configuration list for PBXProject "PinLayoutSample" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Nimble (8.0.2)
-  - PinLayout (1.8.9)
+  - PinLayout (1.8.10)
   - Quick (2.1.0)
   - SwiftLint (0.35.0)
 
@@ -22,10 +22,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Nimble: 622629381bda1dd5678162f21f1368cec7cbba60
-  PinLayout: f7237c104696f409470947fee3ac82e239cac367
+  PinLayout: 641bc9679f73d3da35e04bb5180547cf55fd92d7
   Quick: 4be43f6634acfa727dd106bdf3929ce125ffa79d
   SwiftLint: 5553187048b900c91aa03552807681bb6b027846
 
 PODFILE CHECKSUM: 9b1d14a0f41ae1e8ebc931fa3d033da6c545223e
 
-COCOAPODS: 1.7.1
+COCOAPODS: 1.7.5

--- a/Sources/Impl/PinLayout+Coordinates.swift
+++ b/Sources/Impl/PinLayout+Coordinates.swift
@@ -328,7 +328,7 @@ extension PinLayout {
     }
     
     internal func validateWidth(_ width: CGFloat, context: Context) -> Bool {
-        guard width.isNormal && width >= 0  else {
+        guard width >= 0, width.isFinite else {
             warnWontBeApplied("the width (\(width)) must be greater than or equal to zero.", context)
             return false
         }
@@ -337,7 +337,7 @@ extension PinLayout {
     }
     
     internal func validateComputedWidth(_ width: CGFloat?) -> Bool {
-        if let width = width, !width.isNormal || width < 0 {
+        if let width = width, !width.isFinite || width < 0 {
             return false
         } else {
             return true
@@ -345,7 +345,7 @@ extension PinLayout {
     }
     
     internal func validateHeight(_ height: CGFloat, context: Context) -> Bool {
-        guard height.isNormal && height >= 0 else {
+        guard height >= 0, height.isFinite else {
             warnWontBeApplied("the height (\(height)) must be greater than or equal to zero.", context)
             return false
         }
@@ -354,7 +354,7 @@ extension PinLayout {
     }
     
     internal func validateComputedHeight(_ height: CGFloat?) -> Bool {
-        if let height = height, !height.isNormal || height < 0 {
+        if let height = height, !height.isFinite || height < 0 {
             return false
         } else {
             return true

--- a/Sources/Impl/PinLayout+Coordinates.swift
+++ b/Sources/Impl/PinLayout+Coordinates.swift
@@ -328,16 +328,16 @@ extension PinLayout {
     }
     
     internal func validateWidth(_ width: CGFloat, context: Context) -> Bool {
-        if width < 0 {
+        guard width.isNormal && width >= 0  else {
             warnWontBeApplied("the width (\(width)) must be greater than or equal to zero.", context)
             return false
-        } else {
-            return true
         }
+        
+        return true
     }
     
     internal func validateComputedWidth(_ width: CGFloat?) -> Bool {
-        if let width = width, width < 0 {
+        if let width = width, !width.isNormal || width < 0 {
             return false
         } else {
             return true
@@ -345,16 +345,16 @@ extension PinLayout {
     }
     
     internal func validateHeight(_ height: CGFloat, context: Context) -> Bool {
-        if height < 0 {
+        guard height.isNormal && height >= 0 else {
             warnWontBeApplied("the height (\(height)) must be greater than or equal to zero.", context)
             return false
-        } else {
-            return true
         }
+        
+        return true
     }
     
     internal func validateComputedHeight(_ height: CGFloat?) -> Bool {
-        if let height = height, height < 0 {
+        if let height = height, !height.isNormal || height < 0 {
             return false
         } else {
             return true

--- a/Tests/Common/AdjustSizeSpec.swift
+++ b/Tests/Common/AdjustSizeSpec.swift
@@ -115,6 +115,12 @@ class AdjustSizeSpec: QuickSpec {
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 50.0, height: 60.0)))
             }
             
+            it("should accept a width of 0") {
+                aView.pin.width(0)
+                expect(Pin.lastWarningText).to(beNil())
+                expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 0.0, height: 60.0)))
+            }
+            
             it("should warn about negative width value") {
                 aView.pin.width(-2)
                 expect(Pin.lastWarningText).to(contain(["width", "won't be applied", "the width", "must be greater than or equal to zero"]))
@@ -127,8 +133,20 @@ class AdjustSizeSpec: QuickSpec {
                expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
             }
             
+            it("should warn about -NaN width value") {
+                aView.pin.width(-CGFloat.nan)
+               expect(Pin.lastWarningText).to(contain(["width", "nan", "won't be applied", "the width", "must be greater than or equal to zero"]))
+               expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
+            }
+            
             it("should warn about infinity width value") {
                 aView.pin.width(CGFloat.infinity)
+               expect(Pin.lastWarningText).to(contain(["width", "inf", "won't be applied", "the width", "must be greater than or equal to zero"]))
+               expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
+            }
+            
+            it("should warn about -infinity width value") {
+                aView.pin.width(-CGFloat.infinity)
                expect(Pin.lastWarningText).to(contain(["width", "inf", "won't be applied", "the width", "must be greater than or equal to zero"]))
                expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
             }
@@ -166,6 +184,12 @@ class AdjustSizeSpec: QuickSpec {
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 100.0, height: 30.0)))
             }
             
+            it("should accept a height of 0") {
+                aView.pin.height(0)
+                expect(Pin.lastWarningText).to(beNil())
+                expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 0.0)))
+            }
+            
             it("should warn about negative height value") {
                 aView.pin.height(-2)
                 expect(Pin.lastWarningText).to(contain(["height", "won't be applied", "the height", "must be greater than or equal to zero"]))
@@ -178,8 +202,20 @@ class AdjustSizeSpec: QuickSpec {
                expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
             }
             
+            it("should warn about -NaN height value") {
+                aView.pin.height(-CGFloat.nan)
+               expect(Pin.lastWarningText).to(contain(["height", "nan", "won't be applied", "the height", "must be greater than or equal to zero"]))
+               expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
+            }
+            
             it("should warn about infinity height value") {
                 aView.pin.height(CGFloat.infinity)
+               expect(Pin.lastWarningText).to(contain(["height", "inf", "won't be applied", "the height", "must be greater than or equal to zero"]))
+               expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
+            }
+            
+            it("should warn about -infinity height value") {
+                aView.pin.height(-CGFloat.infinity)
                expect(Pin.lastWarningText).to(contain(["height", "inf", "won't be applied", "the height", "must be greater than or equal to zero"]))
                expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
             }

--- a/Tests/Common/AdjustSizeSpec.swift
+++ b/Tests/Common/AdjustSizeSpec.swift
@@ -114,6 +114,24 @@ class AdjustSizeSpec: QuickSpec {
                 aView.pin.width(of: aViewChild)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 50.0, height: 60.0)))
             }
+            
+            it("should warn about negative width value") {
+                aView.pin.width(-2)
+                expect(Pin.lastWarningText).to(contain(["width", "won't be applied", "the width", "must be greater than or equal to zero"]))
+                expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
+            }
+            
+            it("should warn about NaN width value") {
+                aView.pin.width(CGFloat.nan)
+               expect(Pin.lastWarningText).to(contain(["width", "nan", "won't be applied", "the width", "must be greater than or equal to zero"]))
+               expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
+            }
+            
+            it("should warn about infinity width value") {
+                aView.pin.width(CGFloat.infinity)
+               expect(Pin.lastWarningText).to(contain(["width", "inf", "won't be applied", "the width", "must be greater than or equal to zero"]))
+               expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
+            }
         }
         
         describe("the result of the height(...) methods") {
@@ -146,6 +164,24 @@ class AdjustSizeSpec: QuickSpec {
             it("should adjust the height of aView") {
                 aView.pin.height(of: aViewChild)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 100.0, height: 30.0)))
+            }
+            
+            it("should warn about negative height value") {
+                aView.pin.height(-2)
+                expect(Pin.lastWarningText).to(contain(["height", "won't be applied", "the height", "must be greater than or equal to zero"]))
+                expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
+            }
+            
+            it("should warn about NaN height value") {
+                aView.pin.height(CGFloat.nan)
+               expect(Pin.lastWarningText).to(contain(["height", "nan", "won't be applied", "the height", "must be greater than or equal to zero"]))
+               expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
+            }
+            
+            it("should warn about infinity height value") {
+                aView.pin.height(CGFloat.infinity)
+               expect(Pin.lastWarningText).to(contain(["height", "inf", "won't be applied", "the height", "must be greater than or equal to zero"]))
+               expect(aView.frame).to(equal(CGRect(x: 140, y: 100.0, width: 100.0, height: 60.0)))
             }
         }
         


### PR DESCRIPTION
Improve method that validates `width` and `height` values. Now handle… gracefully NaN and Infinity values.