### PR TITLE
Fix autoSizeThatFits wrong calculations

### DIFF
--- a/Sources/Extensions/UIView+PinLayout.swift
+++ b/Sources/Extensions/UIView+PinLayout.swift
@@ -131,8 +131,9 @@ extension UIView: AutoSizeCalculable {
 
         if (!isAlreadyAutoSizing) {
             Pin.autoSizingInProgress = true
-            autoSizingRect = CGRect(origin: CGPoint.zero, size: size)
         }
+
+        autoSizingRect = CGRect(origin: CGPoint.zero, size: size)
 
         layoutClosure()
 


### PR DESCRIPTION
As I described in #220, there is a problem with size calculations of inner views while using `autoSizeThatFits`. To make it works correctly we need just update autoSizingRect of each views before layout starts.

There is example from ticket with this fix. As you can see it works as it should.
<details>
  <summary>Fixed example</summary>

![autoSizeThatFits](https://user-images.githubusercontent.com/5319811/101754248-94e62f80-3ae4-11eb-9761-94ce576802d1.png)

</details>

@antoinelamy Please check this fix.

Thank you.