### PR TITLE
add filter for autoSizeThatFits

### DIFF
--- a/Sources/AutoSizeCalculable.swift
+++ b/Sources/AutoSizeCalculable.swift
@@ -6,5 +6,5 @@ import AppKit
 
 public protocol AutoSizeCalculable {
     func setAutoSizingRect(_ rect: CGRect, margins: PEdgeInsets)
-    func autoSizeThatFits(_ size: CGSize, layoutClosure: () -> Void) -> CGSize
+    func autoSizeThatFits(_ size: CGSize, layoutClosure: () -> Void, filter: ((_ isInclude: UIView) -> Bool)?) -> CGSize
 }

--- a/Sources/Extensions/UIView+PinLayout.swift
+++ b/Sources/Extensions/UIView+PinLayout.swift
@@ -126,7 +126,7 @@ extension UIView: AutoSizeCalculable {
         self.autoSizingRectWithMargins = Coordinates<View>.adjustRectToDisplayScale(rect.inset(by: margins))
     }
 
-    public func autoSizeThatFits(_ size: CGSize, layoutClosure: () -> Void) -> CGSize {
+    public func autoSizeThatFits(_ size: CGSize, layoutClosure: () -> Void, filter: ((_ isInclude: UIView) -> Bool)? = nil) -> CGSize {
         let isAlreadyAutoSizing = Pin.autoSizingInProgress
 
         if (!isAlreadyAutoSizing) {
@@ -136,7 +136,11 @@ extension UIView: AutoSizeCalculable {
         autoSizingRect = CGRect(origin: CGPoint.zero, size: size)
 
         layoutClosure()
-
+        
+        var subviews = subviews
+        if let filter = filter {
+            subviews = subviews.filter(filter)
+        }
         let boundingRect = subviews.compactMap({ $0.autoSizingRectWithMargins }).reduce(CGRect.zero) { (result: CGRect, autoSizingRect: CGRect) -> CGRect in
             return result.union(autoSizingRect)
         }


### PR DESCRIPTION
add `filter: (UIView) -> Bool` for `func autoSizeThatFits(_:layoutClosure:)`

Developers can use filter to filter the view that needs to do the size calculation.

Maybe some views (isHidden = true) should not be counted.