### PR TITLE
Exclude info.plist to remove SPM warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,12 @@ let package = Package(
         .library(name: "PinLayout", targets: ["PinLayout"])
     ],
     targets: [
-        .target(name: "PinLayout", path: "Sources")
+        .target(
+            name: "PinLayout",
+            path: "Sources",
+            exclude: [
+                "SupportingFiles/Info.plist"
+            ]
+        )
     ]
 )


### PR DESCRIPTION
Building a pin layout, Xcode throws a package warning

> found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target

Exclude Info.plist to remove SPM warning