### PR TITLE
Fix description typo

### DIFF
--- a/Sources/Types.swift
+++ b/Sources/Types.swift
@@ -172,7 +172,7 @@ public enum FitType {
     case widthFlexible
     /**
      Similar to `.height`, except that PinLayout won't constrain the resulting height to
-     match the reference height. The resulting height may be smaller of bigger depending on the view's
+     match the reference height. The resulting height may be smaller or bigger depending on the view's
      sizeThatFits(..) method result.
      */
     case heightFlexible


### PR DESCRIPTION
### Fix description of `FitType.heightFlexible`
`smaller of bigger` -> `smaller or bigger`

<img width="385" alt="image" src="https://user-images.githubusercontent.com/44656036/190937487-a1380982-4ce8-4497-9077-e6295302aff4.png">
