### PR TITLE
Improve Views Concatenation Methods

### DIFF
--- a/Sources/PinLayout+Relative.swift
+++ b/Sources/PinLayout+Relative.swift
@@ -39,6 +39,18 @@ extension PinLayout {
         func context() -> String { return relativeContext("above", relativeViews, aligned) }
         return above(of: relativeViews, aligned: aligned, context: context)
     }
+  
+  @discardableResult
+  public func bottomIfNotAbove(of relativeView: PinView, aligned: HorizontalAlign = .none) -> PinLayout {
+    func context() -> String { return relativeContext("below", [relativeView], aligned) }
+    return bottomIfNotAbove(of: [relativeView], aligned: aligned, context: context)
+  }
+  
+  @discardableResult
+  public func bottomIfNotAbove(of relativeViews: [PinView], aligned: HorizontalAlign = .none) -> PinLayout {
+    func context() -> String { return relativeContext("below", relativeViews, aligned) }
+    return bottomIfNotAbove(of: relativeViews, aligned: aligned, context: context)
+  }
 
     //
     // below(of ...)
@@ -53,6 +65,18 @@ extension PinLayout {
     public func below(of relativeViews: [PinView], aligned: HorizontalAlign = .none) -> PinLayout {
         func context() -> String { return relativeContext("below", relativeViews, aligned) }
         return below(of: relativeViews, aligned: aligned, context: context)
+    }
+  
+    @discardableResult
+    public func topIfNotBelow(of relativeView: PinView, aligned: HorizontalAlign = .none) -> PinLayout {
+      func context() -> String { return relativeContext("below", [relativeView], aligned) }
+      return topIfNotBelow(of: [relativeView], aligned: aligned, context: context)
+    }
+    
+    @discardableResult
+    public func topIfNotBelow(of relativeViews: [PinView], aligned: HorizontalAlign = .none) -> PinLayout {
+      func context() -> String { return relativeContext("below", relativeViews, aligned) }
+      return topIfNotBelow(of: relativeViews, aligned: aligned, context: context)
     }
 
     //
@@ -153,6 +177,30 @@ extension PinLayout {
         }
         return self
     }
+  
+    fileprivate func bottomIfNotAbove(of relativeViews: [PinView], aligned: HorizontalAlign, context: Context) -> PinLayout {
+      guard layoutSuperview(context) != nil else { return self }
+      guard relativeViews.count > 0 else {
+        setBottom(0, context)
+        return self
+      }
+      
+      let anchors: [Anchor]
+      switch aligned {
+      case .left:   anchors = relativeViews.map({ $0.anchor.topLeft })
+      case .center: anchors = relativeViews.map({ $0.anchor.topCenter })
+      case .right:  anchors = relativeViews.map({ $0.anchor.topRight })
+      case .start:  anchors = isLTR() ? relativeViews.map({ $0.anchor.topLeft }) : relativeViews.map({ $0.anchor.topRight })
+      case .end:    anchors = isLTR() ? relativeViews.map({ $0.anchor.topRight }) : relativeViews.map({ $0.anchor.topLeft })
+      case .none:   anchors = relativeViews.map({ $0.anchor.topLeft })
+      }
+      
+      if let coordinates = computeCoordinates(forAnchors: anchors, context) {
+        setBottom(getTopMostCoordinate(list: coordinates), context)
+        applyHorizontalAlignment(aligned, coordinates: coordinates, context: context)
+      }
+      return self
+    }
 
     fileprivate func below(of relativeViews: [PinView], aligned: HorizontalAlign, context: Context) -> PinLayout {
         guard let relativeViews = validateRelativeViews(relativeViews, context: context) else { return self }
@@ -172,6 +220,30 @@ extension PinLayout {
             applyHorizontalAlignment(aligned, coordinates: coordinates, context: context)
         }
         return self
+    }
+  
+    fileprivate func topIfNotBelow(of relativeViews: [PinView], aligned: HorizontalAlign, context: Context ) -> PinLayout {
+      guard layoutSuperview(context) != nil else { return self }
+      guard relativeViews.count > 0 else {
+        setTop(0, context)
+        return self
+      }
+      
+      let anchors: [Anchor]
+      switch aligned {
+      case .left:   anchors = relativeViews.map({ $0.anchor.bottomLeft })
+      case .center: anchors = relativeViews.map({ $0.anchor.bottomCenter })
+      case .right:  anchors = relativeViews.map({ $0.anchor.bottomRight })
+      case .start:  anchors = isLTR() ? relativeViews.map({ $0.anchor.bottomLeft }) : relativeViews.map({ $0.anchor.bottomRight })
+      case .end:    anchors = isLTR() ? relativeViews.map({ $0.anchor.bottomRight }) : relativeViews.map({ $0.anchor.bottomLeft })
+      case .none:   anchors = relativeViews.map({ $0.anchor.bottomLeft })
+      }
+      
+      if let coordinates = computeCoordinates(forAnchors: anchors, context) {
+        setTop(getBottomMostCoordinate(list: coordinates), context)
+        applyHorizontalAlignment(aligned, coordinates: coordinates, context: context)
+      }
+      return self
     }
 
     fileprivate func left(of relativeViews: [PinView], aligned: VerticalAlign, context: Context) -> PinLayout {


### PR DESCRIPTION
### Description
This PR aims to improve to improve the behaviour of methods like `below(of ...` or `above(of ...` allowing to pin the view to the _top/bottom_ of its superview.

### Motivation and Context
Using `PinLayout` frequently to chain views with the following APIs `below(of ...`,  `above(of ...`, or `after(of ...` combined with `visible( ... )` method, it's easy and fast but we often find ourself facing the same problem: the view on top must always be visible. In some cases, however, it would be useful and convenient to overcome this trivial limitation by anchoring the **first visible view** to the superview’s edge.

The solution adopted by me and also my colleagues is to use an `if else` statement inside the `layout` method that check the visibility of the previous/next relative view:

``` swift
func performLayout() {
    firstView.pin
      .top()
      .size(100)
      .hCenter()
      .marginTop(10)
    
    if firstView.isHidden {
      secondView.pin
        .top()
    } else {
      secondView.pin
        .below(of: firstView)
    }
    ...
}
```

With this pull request I would like to discuss a possible solution  implemented as a set of methods that after checking the visibility state of his relative views, instead of causing the layout to fail, pin the view to the edge of the superview (top/bottom/left/right depending on the method used).

```swift
/// Example of a view that is attached below of the last visible `relativeViews`
/// or to `top()` if all relative views are hidden.
@discardableResult
public func topIfNotBelow(of relativeViews: [PinView], aligned: HorizontalAlign = .none) -> PinLayout {
  func context() -> String { return relativeContext("below", relativeViews, aligned) }
  return topIfNotBelow(of: relativeViews, aligned: aligned, context: context)
}

fileprivate func topIfNotBelow(of relativeViews: [PinView], aligned: HorizontalAlign, context: Context ) -> PinLayout {
  guard layoutSuperview(context) != nil else { return self }
  guard relativeViews.count > 0 else {
    setTop(0, context)
    return self
  }
  
  let anchors: [Anchor]
  switch aligned {
  case .left:   anchors = relativeViews.map({ $0.anchor.bottomLeft })
  case .center: anchors = relativeViews.map({ $0.anchor.bottomCenter })
  case .right:  anchors = relativeViews.map({ $0.anchor.bottomRight })
  case .start:  anchors = isLTR() ? relativeViews.map({ $0.anchor.bottomLeft }) : relativeViews.map({ $0.anchor.bottomRight })
  case .end:    anchors = isLTR() ? relativeViews.map({ $0.anchor.bottomRight }) : relativeViews.map({ $0.anchor.bottomLeft })
  case .none:   anchors = relativeViews.map({ $0.anchor.bottomLeft })
  }
  
  if let coordinates = computeCoordinates(forAnchors: anchors, context) {
    setTop(getBottomMostCoordinate(list: coordinates), context)
    applyHorizontalAlignment(aligned, coordinates: coordinates, context: context)
  }
  return self
}
``` 

Using this method as follow:

```swift
func performLayout() {
  redView.pin
    .top()
    .size(100)
    .hCenter()
    .marginTop(10)
  
  blueView.pin
    .topIfNotBelow(of: visible([redView]))
    .size(100)
    .hCenter()
    .marginTop(12)
  
  greenView.pin
    .topIfNotBelow(of: visible([redView, blueView]))
    .size(100)
    .hCenter()
    .marginTop(12)
  
  ...
}
```

I’ll leave here a short video to show animations as well.

https://user-images.githubusercontent.com/16403933/196270311-1e2a0587-b916-4f21-9967-539953ae2c00.mp4

### More Thoughts
It could also be thought of a version of this proposal that improves the names of the methods added by me.
Existing functions (such as `below(of ...)`) could be improved by adding a parameter that describes where the view should be pin in case there are no relative views visible (as default it will maintain the default behaviour):

```swift
enum ParentVerticaAnchor {
  case none
  
  case top
  
  case bottom
  
  case center
}

fileprivate func below(of relativeViews: [PinView], aligned: HorizontalAlign, ifNeeded anchor: ParentVerticaAnchor = .none, context: Context) -> PinLayout {
  guard layoutSuperview(context) != nil else { return self }
  
  switch anchor {
  case .none:
    guard relativeViews.count > 0 else {
      warnWontBeApplied("At least one view must be visible (i.e. UIView.isHidden != true) ", context)
      return self
    }
    
  case .top:
    guard relativeViews.count > 0 else {
      setTop(0, context)
      return self
    }
    
  case .bottom:
    guard relativeViews.count > 0 else {
      setBottom(0, context)
      return self
    }
    
  case .center:
    guard relativeViews.count > 0 else {
      setVerticalCenter(0, context)
      return self
    }
  }
  
  let anchors: [Anchor]
  switch aligned {
    case .left:   anchors = relativeViews.map({ $0.anchor.bottomLeft })
    case .center: anchors = relativeViews.map({ $0.anchor.bottomCenter })
    case .right:  anchors = relativeViews.map({ $0.anchor.bottomRight })
    case .start:  anchors = isLTR() ? relativeViews.map({ $0.anchor.bottomLeft }) : relativeViews.map({ $0.anchor.bottomRight })
    case .end:    anchors = isLTR() ? relativeViews.map({ $0.anchor.bottomRight }) : relativeViews.map({ $0.anchor.bottomLeft })
    case .none:   anchors = relativeViews.map({ $0.anchor.bottomLeft })
  }
  
  if let coordinates = computeCoordinates(forAnchors: anchors, context) {
    setTop(getBottomMostCoordinate(list: coordinates), context)
    applyHorizontalAlignment(aligned, coordinates: coordinates, context: context)
  }
  return self
}
```

