### PR TITLE
Replace `UIScreen.main` to get display scale on iOS 13.0 and later

### DIFF
--- a/Sources/Impl/Coordinates.swift
+++ b/Sources/Impl/Coordinates.swift
@@ -109,8 +109,7 @@ final class Coordinates<PinView: Layoutable> {
 private func getDisplayScale() -> CGFloat {
     #if os(iOS) || os(tvOS)
     if #available(iOS 13.0, tvOS 13.0, *) {
-        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-        return windowScene?.screen.scale ?? 1.0
+        return UITraitCollection.current.displayScale
     } else {
         return UIScreen.main.scale
     }

--- a/Sources/Impl/Coordinates.swift
+++ b/Sources/Impl/Coordinates.swift
@@ -108,7 +108,7 @@ final class Coordinates<PinView: Layoutable> {
 
 private func getDisplayScale() -> CGFloat {
     #if os(iOS) || os(tvOS)
-    if #available(iOS 13.0, *) {
+    if #available(iOS 13.0, tvOS 13.0, *) {
         let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
         return windowScene?.screen.scale ?? .zero
     } else {

--- a/Sources/Impl/Coordinates.swift
+++ b/Sources/Impl/Coordinates.swift
@@ -108,7 +108,12 @@ final class Coordinates<PinView: Layoutable> {
 
 private func getDisplayScale() -> CGFloat {
     #if os(iOS) || os(tvOS)
+    if #available(iOS 13.0, *) {
+        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+        return windowScene?.screen.scale ?? .zero
+    } else {
         return UIScreen.main.scale
+    }
     #elseif os(OSX)
         #if swift(>=4.1)
         return NSScreen.main?.backingScaleFactor ?? 2.0

--- a/Sources/Impl/Coordinates.swift
+++ b/Sources/Impl/Coordinates.swift
@@ -110,7 +110,7 @@ private func getDisplayScale() -> CGFloat {
     #if os(iOS) || os(tvOS)
     if #available(iOS 13.0, tvOS 13.0, *) {
         let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-        return windowScene?.screen.scale ?? .zero
+        return windowScene?.screen.scale ?? 1.0
     } else {
         return UIScreen.main.scale
     }


### PR DESCRIPTION
`UIScree.main` will be deprecated in a future version of iOS.
I used `UIAplication` to get display's scale.

developer doc > [mian](https://developer.apple.com/documentation/uikit/uiscreen/1617815-main) already deprecated. It causes serious errors in the near future.

So have to change another way. And `UIApplication` is the one way of getting display's scale. That is available from `iOS 13.0`. This is why control flow has `iOS 13.0` condition.

