### PR TITLE
fix: fix getDisplayScale

### DIFF
--- a/Sources/Impl/Coordinates.swift
+++ b/Sources/Impl/Coordinates.swift
@@ -109,7 +109,7 @@ final class Coordinates<PinView: Layoutable> {
 private func getDisplayScale() -> CGFloat {
     #if os(iOS) || os(tvOS)
     if #available(iOS 13.0, tvOS 13.0, *) {
-        return UITraitCollection.current.displayScale
+        return max(UITraitCollection.current.displayScale, 1)
     } else {
         return UIScreen.main.scale
     }


### PR DESCRIPTION
#### The default [display scale](https://developer.apple.com/documentation/uikit/uitraitcollection/1623519-displayscale) for a trait collection is 0.0 (indicating unspecified).
<img width="600" alt="Screenshot 2024-01-12 at 12 28 19 PM" src="https://github.com/layoutBox/PinLayout/assets/13270453/5173e33d-0952-43bf-8aeb-12a6dd19ddc6">


#### But, [UIScreen scale](https://developer.apple.com/documentation/uikit/uiscreen/1617836-scale) is for standard-resolution displays(non retina displays), the scale factor is 1.0 and one point equals one pixel.
<img width="600" alt="Screenshot 2024-01-12 at 12 28 58 PM" src="https://github.com/layoutBox/PinLayout/assets/13270453/839868fc-ee83-449a-8aee-f14f4448e922">


#### Related link
https://github.com/airbnb/lottie-ios/pull/2216#discussion_r1378817870