### PR TITLE
Include edge offsets in autoSizeThatFits

### DIFF
--- a/Sources/Impl/PinLayout+Layouting.swift
+++ b/Sources/Impl/PinLayout+Layouting.swift
@@ -135,8 +135,16 @@ extension PinLayout {
         }
 
         if Pin.autoSizingInProgress, let autoSizeCalculable = view as? AutoSizeCalculable {
-            let marginInsets = PEdgeInsets(top: -_marginTop, left: -_marginLeft, bottom: -_marginBottom, right: -_marginRight)
-            autoSizeCalculable.setAutoSizingRect(newRect, margins: marginInsets)
+            let superviewRect = view.superview?.getRect(keepTransform: keepTransform)
+            let bottomOffset = superviewRect.map { $0.height - (_bottom ?? $0.height) } ?? 0
+            let rightOffset = superviewRect.map { $0.width - (_right ?? $0.width) } ?? 0
+            let autoSizingInsets = PEdgeInsets(
+                top: -_marginTop,
+                left: -_marginLeft,
+                bottom: -_marginBottom - bottomOffset,
+                right: -_marginRight - rightOffset
+            )
+            autoSizeCalculable.setAutoSizingRect(newRect, margins: autoSizingInsets)
         } else {
             view.setRect(newRect, keepTransform: keepTransform)
         }

--- a/Tests/Common/LayoutMethodSpec.swift
+++ b/Tests/Common/LayoutMethodSpec.swift
@@ -77,5 +77,56 @@ class LayoutMethodSpec: QuickSpec {
                 expect(Pin.lastWarningText).to(contain(["PinLayout commands have been issued without calling the 'layout()' method"]))
             }
         }
+
+        #if os(iOS) || os(tvOS)
+        describe("autoSizeThatFits()") {
+            it("should include edge offsets in the resulting size") {
+                defer { Pin.layoutDirection(.auto) }
+
+                let bView = BasicView()
+                rootView.addSubview(bView)
+
+                let aViewFrame = aView.frame
+                let bViewFrame = bView.frame
+                let availableSize = CGSize(width: 400, height: 400)
+
+                func performLayout() {
+                    aView.pin.size(50).start(16).top(16).bottom(16)
+                    bView.pin.size(50).top(16).end(16).bottom(16)
+                }
+
+                func autoSizedResult() -> CGSize {
+                    return rootView.autoSizeThatFits(availableSize, layoutClosure: performLayout)
+                }
+
+                Pin.layoutDirection(.ltr)
+                let size = autoSizedResult()
+                expect(size).to(equal(CGSize(width: 400, height: 82)))
+
+                expect(aView.frame).to(equal(aViewFrame))
+                expect(bView.frame).to(equal(bViewFrame))
+
+                rootView.frame = CGRect(origin: .zero, size: size)
+                performLayout()
+                expect(aView.frame).to(equal(CGRect(x: 16, y: 16, width: 50, height: 50)))
+                expect(bView.frame).to(equal(CGRect(x: 334, y: 16, width: 50, height: 50)))
+
+                Pin.layoutDirection(.rtl)
+                expect(autoSizedResult()).to(equal(size))
+
+                performLayout()
+                expect(aView.frame).to(equal(CGRect(x: 334, y: 16, width: 50, height: 50)))
+                expect(bView.frame).to(equal(CGRect(x: 16, y: 16, width: 50, height: 50)))
+            }
+
+            it("should preserve negative leading edge offsets") {
+                let size = rootView.autoSizeThatFits(CGSize(width: 400, height: 400)) {
+                    aView.pin.left(-10).top(-20).size(50)
+                }
+
+                expect(size).to(equal(CGSize(width: 50, height: 50)))
+            }
+        }
+        #endif
     }
 }


### PR DESCRIPTION
# What is this PR?

Fix `autoSizeThatFits` so trailing and bottom edge offsets are included in the calculated size.

Closes #276

## Reproduction

```swift
private func performPinLayout() {
    view1.pin.size(50).start(16).top(16).bottom(16)
    view2.pin.size(50).top(16).end(16).bottom(16)
}

override func layoutSubviews() {
    super.layoutSubviews()
    performPinLayout()
}

override func sizeThatFits(_ size: CGSize) -> CGSize {
    autoSizeThatFits(size, layoutClosure: performPinLayout)
}
```

`sizeThatFits` now returns the expected height of `82`.

## Tests

- LTR and RTL auto sizing, followed by actual frame placement
- Negative leading offsets remain unchanged
- `LayoutMethodSpec` passes

<img width="300" alt="Issue #276 reproduction" src="https://github.com/user-attachments/assets/ffb87f2b-1b86-4698-8ea5-17047525cc06" />
